### PR TITLE
docs: add FUNDING.yml for GitHub sponsorship

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [vbreuss]


### PR DESCRIPTION
This PR adds GitHub sponsorship configuration by creating a FUNDING.yml file in the .github directory. This enables the "Sponsor" button on the repository's GitHub page.