### PR TITLE
feat: add `AtLeast` and `AtMost` expectations

### DIFF
--- a/Source/aweXpect.Mockolate/ThatCheckResult.AtLeast.cs
+++ b/Source/aweXpect.Mockolate/ThatCheckResult.AtLeast.cs
@@ -1,0 +1,18 @@
+﻿using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Results;
+using Mockolate.Checks;
+
+namespace aweXpect;
+
+public static partial class ThatCheckResult
+{
+	/// <summary>
+	///     Verifies that the checked interaction happened at least the number of <paramref name="times"/>.
+	/// </summary>
+	public static AndOrResult<CheckResult<TMock>, IThat<CheckResult<TMock>>> AtLeast<TMock>(
+		this IThat<CheckResult<TMock>> subject, Times times)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars)
+				=> new HasAtLeastConstraint<TMock>(expectationBuilder, it, grammars, times.Value)),
+			subject);
+}

--- a/Source/aweXpect.Mockolate/ThatCheckResult.AtLeastOnce.cs
+++ b/Source/aweXpect.Mockolate/ThatCheckResult.AtLeastOnce.cs
@@ -1,0 +1,18 @@
+﻿using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Results;
+using Mockolate.Checks;
+
+namespace aweXpect;
+
+public static partial class ThatCheckResult
+{
+	/// <summary>
+	///     Verifies that the checked interaction happened at least once.
+	/// </summary>
+	public static AndOrResult<CheckResult<TMock>, IThat<CheckResult<TMock>>> AtLeastOnce<TMock>(
+		this IThat<CheckResult<TMock>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars)
+				=> new HasAtLeastConstraint<TMock>(expectationBuilder, it, grammars, 1)),
+			subject);
+}

--- a/Source/aweXpect.Mockolate/ThatCheckResult.AtLeastTwice.cs
+++ b/Source/aweXpect.Mockolate/ThatCheckResult.AtLeastTwice.cs
@@ -1,0 +1,18 @@
+﻿using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Results;
+using Mockolate.Checks;
+
+namespace aweXpect;
+
+public static partial class ThatCheckResult
+{
+	/// <summary>
+	///     Verifies that the checked interaction happened at least twice.
+	/// </summary>
+	public static AndOrResult<CheckResult<TMock>, IThat<CheckResult<TMock>>> AtLeastTwice<TMock>(
+		this IThat<CheckResult<TMock>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars)
+				=> new HasAtLeastConstraint<TMock>(expectationBuilder, it, grammars, 2)),
+			subject);
+}

--- a/Source/aweXpect.Mockolate/ThatCheckResult.AtMost.cs
+++ b/Source/aweXpect.Mockolate/ThatCheckResult.AtMost.cs
@@ -1,0 +1,18 @@
+﻿using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Results;
+using Mockolate.Checks;
+
+namespace aweXpect;
+
+public static partial class ThatCheckResult
+{
+	/// <summary>
+	///     Verifies that the checked interaction happened at most the number of <paramref name="times"/>.
+	/// </summary>
+	public static AndOrResult<CheckResult<TMock>, IThat<CheckResult<TMock>>> AtMost<TMock>(
+		this IThat<CheckResult<TMock>> subject, Times times)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars)
+				=> new HasAtMostConstraint<TMock>(expectationBuilder, it, grammars, times.Value)),
+			subject);
+}

--- a/Source/aweXpect.Mockolate/ThatCheckResult.AtMostOnce.cs
+++ b/Source/aweXpect.Mockolate/ThatCheckResult.AtMostOnce.cs
@@ -1,0 +1,18 @@
+﻿using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Results;
+using Mockolate.Checks;
+
+namespace aweXpect;
+
+public static partial class ThatCheckResult
+{
+	/// <summary>
+	///     Verifies that the checked interaction happened at most once.
+	/// </summary>
+	public static AndOrResult<CheckResult<TMock>, IThat<CheckResult<TMock>>> AtMostOnce<TMock>(
+		this IThat<CheckResult<TMock>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars)
+				=> new HasAtMostConstraint<TMock>(expectationBuilder, it, grammars, 1)),
+			subject);
+}

--- a/Source/aweXpect.Mockolate/ThatCheckResult.AtMostTwice.cs
+++ b/Source/aweXpect.Mockolate/ThatCheckResult.AtMostTwice.cs
@@ -1,0 +1,18 @@
+﻿using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Results;
+using Mockolate.Checks;
+
+namespace aweXpect;
+
+public static partial class ThatCheckResult
+{
+	/// <summary>
+	///     Verifies that the checked interaction happened at most twice.
+	/// </summary>
+	public static AndOrResult<CheckResult<TMock>, IThat<CheckResult<TMock>>> AtMostTwice<TMock>(
+		this IThat<CheckResult<TMock>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars)
+				=> new HasAtMostConstraint<TMock>(expectationBuilder, it, grammars, 2)),
+			subject);
+}

--- a/Source/aweXpect.Mockolate/ThatCheckResult.cs
+++ b/Source/aweXpect.Mockolate/ThatCheckResult.cs
@@ -122,7 +122,7 @@ public static partial class ThatCheckResult
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append("found ").Append(it).Append(" ").Append(_count.ToAmountString());
+			stringBuilder.Append("found ").Append(it).Append(' ').Append(_count.ToAmountString());
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
@@ -205,7 +205,7 @@ public static partial class ThatCheckResult
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append("found ").Append(it).Append(" ").Append(_count.ToAmountString());
+			stringBuilder.Append("found ").Append(it).Append(' ').Append(_count.ToAmountString());
 		}
 
 		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default

--- a/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net8.0.txt
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net8.0.txt
@@ -4,6 +4,12 @@ namespace aweXpect
 {
     public static class ThatCheckResult
     {
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtLeast<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject, aweXpect.Core.Times times) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtLeastOnce<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtLeastTwice<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtMost<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject, aweXpect.Core.Times times) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtMostOnce<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtMostTwice<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> Exactly<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject, aweXpect.Core.Times times) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> Never<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> Once<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }

--- a/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_netstandard2.0.txt
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_netstandard2.0.txt
@@ -4,6 +4,12 @@ namespace aweXpect
 {
     public static class ThatCheckResult
     {
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtLeast<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject, aweXpect.Core.Times times) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtLeastOnce<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtLeastTwice<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtMost<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject, aweXpect.Core.Times times) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtMostOnce<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> AtMostTwice<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> Exactly<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject, aweXpect.Core.Times times) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> Never<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Checks.CheckResult<TMock>, aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>>> Once<TMock>(this aweXpect.Core.IThat<Mockolate.Checks.CheckResult<TMock>> subject) { }

--- a/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtLeastOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtLeastOnceTests.cs
@@ -1,0 +1,72 @@
+﻿using Mockolate;
+using Xunit.Sdk;
+
+namespace aweXpect.Mockolate.Tests;
+
+public sealed partial class ThatCheckResultIs
+{
+	public sealed class AtLeastOnceTests
+	{
+		[Fact]
+		public async Task WhenInvokedTwice_ShouldSucceed()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeastOnce();
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenInvokedMoreThanTwice_ShouldSucceed()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeastOnce();
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenInvokedNever_ShouldFail()
+		{
+			var mock = Mock.Create<IMyService>();
+
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeastOnce();
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+					Expected that the Mock<ThatCheckResultIs.IMyService>
+					invoked method MyMethod(1, False) at least once,
+					but never found it
+					
+					Interactions:
+					[]
+					""");
+		}
+
+		[Fact]
+		public async Task WhenInvokedOnce_ShouldSucceed()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeastOnce();
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtLeastOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtLeastOnceTests.cs
@@ -41,7 +41,6 @@ public sealed partial class ThatCheckResultIs
 		{
 			var mock = Mock.Create<IMyService>();
 
-
 			async Task Act()
 				=> await That(mock.Invoked.MyMethod(1, false)).AtLeastOnce();
 

--- a/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtLeastTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtLeastTests.cs
@@ -1,0 +1,97 @@
+﻿using Mockolate;
+using Xunit.Sdk;
+
+namespace aweXpect.Mockolate.Tests;
+
+public sealed partial class ThatCheckResultIs
+{
+	public sealed class AtLeastTests
+	{
+		[Theory]
+		[InlineData(0, false)]
+		[InlineData(3, true)]
+		[InlineData(8, true)]
+		public async Task WhenInvokedNever_ShouldFailUnlessZero(int times, bool shouldThrow)
+		{
+			var mock = Mock.Create<IMyService>();
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeast(times);
+
+			await That(Act).Throws<XunitException>().OnlyIf(shouldThrow)
+				.WithMessage($"""
+					Expected that the Mock<ThatCheckResultIs.IMyService>
+					invoked method MyMethod(1, False) at least {times} times,
+					but never found it
+					
+					Interactions:
+					[]
+					""");
+		}
+
+		[Theory]
+		[InlineData(4, 3)]
+		[InlineData(8, 6)]
+		public async Task WhenInvokedFewerTimes_ShouldFail(int times, int invocationTimes)
+		{
+			var mock = Mock.Create<IMyService>();
+
+			for (var i = 0; i < invocationTimes; i++)
+			{
+				mock.Object.MyMethod(1, false);
+			}
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeast(times);
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage($"""
+					Expected that the Mock<ThatCheckResultIs.IMyService>
+					invoked method MyMethod(1, False) at least {times} times,
+					but found it only {invocationTimes} times
+					
+					Interactions:
+					[
+					*
+					]
+					""").AsWildcard();
+		}
+
+		[Theory]
+		[InlineData(3, 4)]
+		[InlineData(6, 8)]
+		public async Task WhenInvokedMoreOften_ShouldSucceed(int times, int invocationTimes)
+		{
+			var mock = Mock.Create<IMyService>();
+
+			for (var i = 0; i < invocationTimes; i++)
+			{
+				mock.Object.MyMethod(1, false);
+			}
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeast(times);
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		[InlineData(3)]
+		[InlineData(6)]
+		[InlineData(18)]
+		public async Task WhenInvokedAtLeastTheSameTimes_ShouldSucceed(int times)
+		{
+			var mock = Mock.Create<IMyService>();
+
+			for (var i = 0; i < times; i++)
+			{
+				mock.Object.MyMethod(1, false);
+			}
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeast(times);
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtLeastTwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtLeastTwiceTests.cs
@@ -1,0 +1,81 @@
+﻿using Mockolate;
+using Xunit.Sdk;
+
+namespace aweXpect.Mockolate.Tests;
+
+public sealed partial class ThatCheckResultIs
+{
+	public sealed class AtLeastTwiceTests
+	{
+		[Fact]
+		public async Task WhenInvokedTwice_ShouldSucceed()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeastTwice();
+
+			await That(Act).DoesNotThrow();
+		}
+		[Fact]
+		public async Task WhenInvokedMoreThanTwice_ShouldSucceed()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeastTwice();
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenInvokedNever_ShouldFail()
+		{
+			var mock = Mock.Create<IMyService>();
+
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeastTwice();
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+					Expected that the Mock<ThatCheckResultIs.IMyService>
+					invoked method MyMethod(1, False) at least twice,
+					but never found it
+					
+					Interactions:
+					[]
+					""");
+		}
+
+		[Fact]
+		public async Task WhenInvokedOnce_ShouldFail()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtLeastTwice();
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+					Expected that the Mock<ThatCheckResultIs.IMyService>
+					invoked method MyMethod(1, False) at least twice,
+					but found it only once
+					
+					Interactions:
+					[
+					  [0] invoke method aweXpect.Mockolate.Tests.ThatCheckResultIs.IMyService.MyMethod(1, False)
+					]
+					""");
+		}
+	}
+}

--- a/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtLeastTwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtLeastTwiceTests.cs
@@ -40,7 +40,6 @@ public sealed partial class ThatCheckResultIs
 		{
 			var mock = Mock.Create<IMyService>();
 
-
 			async Task Act()
 				=> await That(mock.Invoked.MyMethod(1, false)).AtLeastTwice();
 

--- a/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtMostOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtMostOnceTests.cs
@@ -1,0 +1,86 @@
+﻿using Mockolate;
+using Xunit.Sdk;
+
+namespace aweXpect.Mockolate.Tests;
+
+public sealed partial class ThatCheckResultIs
+{
+	public sealed class AtMostOnceTests
+	{
+		[Fact]
+		public async Task WhenInvokedTwice_ShouldFail()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtMostOnce();
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+					Expected that the Mock<ThatCheckResultIs.IMyService>
+					invoked method MyMethod(1, False) at most once,
+					but found it twice
+
+					Interactions:
+					[
+					  [0] invoke method aweXpect.Mockolate.Tests.ThatCheckResultIs.IMyService.MyMethod(1, False),
+					  [1] invoke method aweXpect.Mockolate.Tests.ThatCheckResultIs.IMyService.MyMethod(1, False)
+					]
+					""");
+		}
+		[Fact]
+		public async Task WhenInvokedMoreThanTwice_ShouldFail()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtMostOnce();
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+					Expected that the Mock<ThatCheckResultIs.IMyService>
+					invoked method MyMethod(1, False) at most once,
+					but found it 3 times
+
+					Interactions:
+					[
+					  [0] invoke method aweXpect.Mockolate.Tests.ThatCheckResultIs.IMyService.MyMethod(1, False),
+					  [1] invoke method aweXpect.Mockolate.Tests.ThatCheckResultIs.IMyService.MyMethod(1, False),
+					  [2] invoke method aweXpect.Mockolate.Tests.ThatCheckResultIs.IMyService.MyMethod(1, False)
+					]
+					""");
+		}
+
+		[Fact]
+		public async Task WhenInvokedNever_ShouldSucceed()
+		{
+			var mock = Mock.Create<IMyService>();
+
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtMostOnce();
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenInvokedOnce_ShouldSucceed()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtMostOnce();
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtMostOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtMostOnceTests.cs
@@ -63,7 +63,6 @@ public sealed partial class ThatCheckResultIs
 		{
 			var mock = Mock.Create<IMyService>();
 
-
 			async Task Act()
 				=> await That(mock.Invoked.MyMethod(1, false)).AtMostOnce();
 

--- a/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtMostTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtMostTests.cs
@@ -1,0 +1,76 @@
+﻿using Mockolate;
+using Xunit.Sdk;
+
+namespace aweXpect.Mockolate.Tests;
+
+public sealed partial class ThatCheckResultIs
+{
+	public sealed class AtMost
+	{
+		[Theory]
+		[InlineData(2, 0)]
+		[InlineData(4, 3)]
+		[InlineData(8, 6)]
+		public async Task WhenInvokedFewerTimes_ShouldSucceed(int times, int invocationTimes)
+		{
+			var mock = Mock.Create<IMyService>();
+
+			for (var i = 0; i < invocationTimes; i++)
+			{
+				mock.Object.MyMethod(1, false);
+			}
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtMost(times);
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Theory]
+		[InlineData(3, 4)]
+		[InlineData(6, 8)]
+		public async Task WhenInvokedMoreOften_ShouldFail(int times, int invocationTimes)
+		{
+			var mock = Mock.Create<IMyService>();
+
+			for (var i = 0; i < invocationTimes; i++)
+			{
+				mock.Object.MyMethod(1, false);
+			}
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtMost(times);
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage($"""
+					Expected that the Mock<ThatCheckResultIs.IMyService>
+					invoked method MyMethod(1, False) at most {times} times,
+					but found it {invocationTimes} times
+					
+					Interactions:
+					[
+					*
+					]
+					""").AsWildcard();
+		}
+
+		[Theory]
+		[InlineData(3)]
+		[InlineData(6)]
+		[InlineData(18)]
+		public async Task WhenInvokedAtMostTheSameTimes_ShouldSucceed(int times)
+		{
+			var mock = Mock.Create<IMyService>();
+
+			for (var i = 0; i < times; i++)
+			{
+				mock.Object.MyMethod(1, false);
+			}
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtMost(times);
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+}

--- a/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtMostTwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtMostTwiceTests.cs
@@ -52,7 +52,6 @@ public sealed partial class ThatCheckResultIs
 		{
 			var mock = Mock.Create<IMyService>();
 
-
 			async Task Act()
 				=> await That(mock.Invoked.MyMethod(1, false)).AtMostTwice();
 

--- a/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtMostTwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatCheckResultIs.AtMostTwiceTests.cs
@@ -1,0 +1,75 @@
+﻿using Mockolate;
+using Xunit.Sdk;
+
+namespace aweXpect.Mockolate.Tests;
+
+public sealed partial class ThatCheckResultIs
+{
+	public sealed class AtMostTwiceTests
+	{
+		[Fact]
+		public async Task WhenInvokedTwice_ShouldSucceed()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtMostTwice();
+
+			await That(Act).DoesNotThrow();
+		}
+		[Fact]
+		public async Task WhenInvokedMoreThanTwice_ShouldFail()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtMostTwice();
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+					Expected that the Mock<ThatCheckResultIs.IMyService>
+					invoked method MyMethod(1, False) at most twice,
+					but found it 3 times
+
+					Interactions:
+					[
+					  [0] invoke method aweXpect.Mockolate.Tests.ThatCheckResultIs.IMyService.MyMethod(1, False),
+					  [1] invoke method aweXpect.Mockolate.Tests.ThatCheckResultIs.IMyService.MyMethod(1, False),
+					  [2] invoke method aweXpect.Mockolate.Tests.ThatCheckResultIs.IMyService.MyMethod(1, False)
+					]
+					""");
+		}
+
+		[Fact]
+		public async Task WhenInvokedNever_ShouldSucceed()
+		{
+			var mock = Mock.Create<IMyService>();
+
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtMostTwice();
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenInvokedOnce_ShouldSucceed()
+		{
+			var mock = Mock.Create<IMyService>();
+
+			mock.Object.MyMethod(1, false);
+
+			async Task Act()
+				=> await That(mock.Invoked.MyMethod(1, false)).AtMostTwice();
+
+			await That(Act).DoesNotThrow();
+		}
+	}
+}


### PR DESCRIPTION
This PR adds `AtLeast` and `AtMost` expectation methods to the aweXpect.Mockolate library for verifying mock interaction counts with minimum and maximum bounds.

### Key changes:
- Adds `AtLeast`, `AtLeastOnce`, `AtLeastTwice` methods for minimum invocation count verification
- Adds `AtMost`, `AtMostOnce`, `AtMostTwice` methods for maximum invocation count verification
- Includes comprehensive test coverage for all new expectation methods