### PR TITLE
docs: include tagline

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,5 +1,7 @@
-﻿# [aweXpect.Mockolate](https://github.com/aweXpect/aweXpect.Mockolate) [![Nuget](https://img.shields.io/nuget/v/aweXpect.Mockolate)](https://www.nuget.org/packages/aweXpect.Mockolate)
+﻿# [aweXpect.Mockolate](https://github.com/aweXpect/aweXpect.Mockolate)
 
-Template for extension projects for [aweXpect](https://github.com/aweXpect/aweXpect).
+[![Nuget](https://img.shields.io/nuget/v/aweXpect.Mockolate)](https://www.nuget.org/packages/aweXpect.Mockolate)
+
+[aweXpect.Mockolate](https://github.com/aweXpect/aweXpect.Mockolate) contains expectations to verify interactions with mocks from [Mockolate](https://github.com/aweXpect/Mockolate).
 
 {README}

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -5,7 +5,7 @@
 
 	<PropertyGroup>
 		<Authors>aweXpect</Authors>
-		<Description>Template for extension projects for aweXpect.</Description>
+		<Description>Expectations to verify interactions with mocks from Mockolate.</Description>
 		<Copyright>Copyright (c) 2025 - $([System.DateTime]::Now.ToString('yyyy')) Valentin Breuß</Copyright>
 		<RepositoryUrl>https://github.com/aweXpect/aweXpect.Mockolate.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>


### PR DESCRIPTION
This PR updates documentation to replace template content with the actual project description for aweXpect.Mockolate. The changes clarify that this library provides expectations for verifying interactions with mocks from the Mockolate framework.

- Updated project description from generic template text to specific functionality
- Modified documentation header structure and added project tagline