### PR TITLE
refactor: use xunit v2 to enable stryker mutation testing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,30 +1,31 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="aweXpect" Version="2.26.0" />
-    <PackageVersion Include="aweXpect.Core" Version="2.24.0" />
-	<PackageVersion Include="Mockolate" Version="0.5.4" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageVersion Include="Nullable" Version="1.3.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageVersion Include="Nuke.Common" Version="9.0.4" />
-    <PackageVersion Include="Nuke.Components" Version="9.0.4" />
-    <PackageVersion Include="LibGit2Sharp" Version="0.30.0" />
-    <PackageVersion Include="SharpCompress" Version="0.39.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.163" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="xunit.v3" Version="3.0.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="PublicApiGenerator" Version="11.4.6" />
-  </ItemGroup>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageVersion Include="aweXpect" Version="2.26.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.24.0" />
+		<PackageVersion Include="Mockolate" Version="0.5.4" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageVersion Include="Nullable" Version="1.3.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageVersion Include="Nuke.Common" Version="9.0.4" />
+		<PackageVersion Include="Nuke.Components" Version="9.0.4" />
+		<PackageVersion Include="LibGit2Sharp" Version="0.30.0" />
+		<PackageVersion Include="SharpCompress" Version="0.39.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageVersion Include="Meziantou.Analyzer" Version="2.0.163" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+		<PackageVersion Include="xunit" Version="2.9.3"/>
+		<PackageVersion Include="xunit.v3" Version="3.0.1"/>
+		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
+		<PackageVersion Include="coverlet.collector" Version="6.0.4" />
+		<PackageVersion Include="PublicApiGenerator" Version="11.4.6" />
+	</ItemGroup>
 </Project>

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -18,8 +18,18 @@
 		<NoWarn>701;1702;CA1845</NoWarn>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
+		<OutputType>exe</OutputType>
+	</PropertyGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
 		<PackageReference Include="xunit.v3"/>
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+		<PackageReference Include="xunit"/>
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/Tests/aweXpect.Mockolate.Api.Tests/aweXpect.Mockolate.Api.Tests.csproj
+++ b/Tests/aweXpect.Mockolate.Api.Tests/aweXpect.Mockolate.Api.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0</TargetFrameworks>
@@ -9,10 +9,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Remove="xunit" />
+		<PackageReference Include="xunit.v3" />
 		<PackageReference Include="PublicApiGenerator" />
 	</ItemGroup>
-
-	<ItemGroup>
-		<Folder Include="Expected\" />
-	</ItemGroup>
+	
 </Project>


### PR DESCRIPTION
This PR refactors the test infrastructure to use xunit v2 to enable Stryker mutation testing. The changes involve updating package references and configurations to support both xunit v2 and v3 depending on the target framework.

### Key changes:
- Updates xunit package references to conditionally use v2 for non-net48 frameworks and v3 for net48
- Removes explicit xunit references from specific test projects in favor of centralized configuration
- Updates xunit.runner.visualstudio version and adds configuration for net48 target framework