### PR TITLE
chore: update to v0.9.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.26.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.24.0" />
-		<PackageVersion Include="Mockolate" Version="0.9.0" />
+		<PackageVersion Include="Mockolate" Version="0.9.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
@@ -7,7 +7,6 @@ using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Results;
-using Mockolate;
 using Mockolate.Verify;
 using Mockolate.Interactions;
 
@@ -40,7 +39,8 @@ public static partial class ThatVerificationResult
 			Actual = actual;
 			_expectations.Clear();
 			bool result = true;
-			IVerificationResult<TVerify> verificationResult = actual;
+			TVerify verify = ((IVerificationResult<TVerify>)actual).Object;
+			IVerificationResult verificationResult = actual;
 			int after = -1;
 			foreach (Func<TVerify, VerificationResult<TVerify>>? check in interactions)
 			{
@@ -49,7 +49,7 @@ public static partial class ThatVerificationResult
 				{
 					result = false;
 				}
-				verificationResult = check(verificationResult.Object);
+				verificationResult = check(verify);
 			}
 
 			_expectations.Add(verificationResult.Expectation);

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.cs
@@ -25,7 +25,7 @@ public static partial class ThatVerificationResult
 
 		public ConstraintResult IsMetBy(VerificationResult<TVerify> actual)
 		{
-			IVerificationResult<TVerify> result = actual;
+			IVerificationResult result = actual;
 			_expectation = result.Expectation;
 			Actual = actual;
 			Outcome = result.Verify(interactions =>
@@ -106,7 +106,7 @@ public static partial class ThatVerificationResult
 
 		public ConstraintResult IsMetBy(VerificationResult<TVerify> actual)
 		{
-			IVerificationResult<TVerify> result = actual;
+			IVerificationResult result = actual;
 			_expectation = result.Expectation;
 			Actual = actual;
 			Outcome = result.Verify(interactions =>
@@ -175,7 +175,7 @@ public static partial class ThatVerificationResult
 
 		public ConstraintResult IsMetBy(VerificationResult<TVerify> actual)
 		{
-			IVerificationResult<TVerify> result = actual;
+			IVerificationResult result = actual;
 			_expectation = result.Expectation;
 			Actual = actual;
 			Outcome = result.Verify(interactions =>


### PR DESCRIPTION
This PR updates the Mockolate package dependency from version 0.9.0 to 0.9.1 and adapts the codebase to accommodate breaking changes in the updated library. The changes primarily involve updating generic type references and interface usage to align with the new Mockolate API.
