### PR TITLE
chore: bump the aweXpect group

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.26.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.24.0" />
+		<PackageVersion Include="aweXpect" Version="2.27.1" />
+		<PackageVersion Include="aweXpect.Core" Version="2.25.1" />
 		<PackageVersion Include="Mockolate" Version="0.10.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
@@ -59,7 +59,7 @@ public static partial class ThatVerificationResult
 			{
 				string context = Formatter.Format(((IVerificationResult)actual).MockInteractions.Interactions, FormattingOptions.MultipleLines);
 				expectationBuilder.UpdateContexts(contexts => contexts.Add(
-					new ResultContext("Interactions", () => context)));
+					new ResultContext.SyncCallback("Interactions", () => context)));
 			}
 			return this;
 			bool VerifyInteractions(IInteraction[] interactions)

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.cs
@@ -32,7 +32,7 @@ public static partial class ThatVerificationResult
 			{
 				string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 				expectationBuilder.UpdateContexts(contexts => contexts.Add(
-					new ResultContext("Interactions", () => context)));
+					new ResultContext.SyncCallback("Interactions", () => context)));
 				_count = interactions.Length;
 				return interactions.Length == expected;
 			})
@@ -113,7 +113,7 @@ public static partial class ThatVerificationResult
 			{
 				string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 				expectationBuilder.UpdateContexts(contexts => contexts.Add(
-					new ResultContext("Interactions", () => context)));
+					new ResultContext.SyncCallback("Interactions", () => context)));
 				_count = interactions.Length;
 				return interactions.Length <= expected;
 			})
@@ -182,7 +182,7 @@ public static partial class ThatVerificationResult
 			{
 				string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 				expectationBuilder.UpdateContexts(contexts => contexts.Add(
-					new ResultContext("Interactions", () => context)));
+					new ResultContext.SyncCallback("Interactions", () => context)));
 				_count = interactions.Length;
 				return interactions.Length >= expected;
 			})


### PR DESCRIPTION
This PR updates the aweXpect package dependencies and adapts the code to use the new `ResultContext.SyncCallback` API introduced in the updated version.

### Key changes
- Updated aweXpect from 2.26.0 to 2.27.1 and aweXpect.Core from 2.24.0 to 2.25.1
- Replaced `ResultContext` constructor calls with `ResultContext.SyncCallback` across multiple files
- Changes maintain consistent context reporting for mock interactions