### PR TITLE
fix: disable mutation tests

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -22,6 +22,7 @@ namespace Build;
 
 partial class Build
 {
+	private static bool DisableMutationTests = true;
 	static string MutationCommentBody = "";
 
 	Target MutationTests => _ => _
@@ -30,6 +31,7 @@ partial class Build
 
 	Target MutationTestExecution => _ => _
 		.DependsOn(Compile)
+		.OnlyWhenDynamic(() => !DisableMutationTests)
 		.Executes(() =>
 		{
 			AbsolutePath toolPath = TestResultsDirectory / "dotnet-stryker";
@@ -109,6 +111,7 @@ partial class Build
 	Target MutationComment => _ => _
 		.After(MutationTestExecution)
 		.OnlyWhenDynamic(() => GitHubActions.IsPullRequest)
+		.OnlyWhenDynamic(() => !DisableMutationTests)
 		.Executes(() =>
 		{
 			int? prId = GitHubActions.PullRequestNumber;
@@ -132,6 +135,7 @@ partial class Build
 
 	Target MutationTestDashboard => _ => _
 		.After(MutationTestExecution)
+		.OnlyWhenDynamic(() => !DisableMutationTests)
 		.Executes(async () =>
 		{
 			await "MutationTests".DownloadArtifactTo(ArtifactsDirectory, GithubToken);


### PR DESCRIPTION
This PR disables mutation testing by introducing a configuration flag. The change prevents mutation test execution, commenting, and dashboard generation from running in the build pipeline.

### Key Changes:
- Added a `DisableMutationTests` flag set to `true`
- Applied the flag as a condition to three mutation testing targets