### PR TITLE
docs: fix headline in documentation

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,4 +1,4 @@
-﻿# [aweXpect.Mockolate](https://github.com/aweXpect/aweXpect.Mockolate)
+﻿# aweXpect.Mockolate
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Mockolate)](https://www.nuget.org/packages/aweXpect.Mockolate)
 


### PR DESCRIPTION
This PR simplifies the main documentation heading by removing the GitHub repository link and keeping only the plain text title "aweXpect.Mockolate".

- Removed hyperlink wrapper from the main heading in the index documentation