### PR TITLE
chore: update aweXpect

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.27.1" />
-		<PackageVersion Include="aweXpect.Core" Version="2.25.1" />
+		<PackageVersion Include="aweXpect" Version="2.29.0" />
+		<PackageVersion Include="aweXpect.Core" Version="2.26.0" />
 		<PackageVersion Include="Mockolate" Version="0.10.0" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
This PR updates the aweXpect testing framework packages to their latest versions.

- aweXpect upgraded from 2.27.1 to 2.29.0
- aweXpect.Core upgraded from 2.25.1 to 2.26.0