### PR TITLE
feat: add `AllInteractionsAreVerified`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.29.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.26.0" />
-		<PackageVersion Include="Mockolate" Version="0.35.1" />
+		<PackageVersion Include="Mockolate" Version="0.36.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />

--- a/Source/aweXpect.Mockolate/Helpers/MyDescribableSubject.cs
+++ b/Source/aweXpect.Mockolate/Helpers/MyDescribableSubject.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using aweXpect.Core;
+
+namespace aweXpect.Helpers;
+
+internal sealed class MyDescribableSubject<TVerify> : IDescribableSubject
+{
+	public string GetDescription()
+	{
+		string mockVerify = Formatter.Format(typeof(TVerify));
+		if (mockVerify.StartsWith("MockVerify", StringComparison.Ordinal))
+		{
+			mockVerify = $"Mock{mockVerify.Substring("MockVerify".Length)}";
+			int genericSeparator = mockVerify.IndexOf(", ", StringComparison.Ordinal);
+			if (genericSeparator > 0)
+			{
+				mockVerify = $"{mockVerify.Substring(0, genericSeparator)}>";
+			}
+		}
+
+		return $"the {mockVerify} mock";
+	}
+}

--- a/Source/aweXpect.Mockolate/ThatMockVerify.AllInteractionsAreVerified.cs
+++ b/Source/aweXpect.Mockolate/ThatMockVerify.AllInteractionsAreVerified.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+using Mockolate;
+using Mockolate.Interactions;
+using Mockolate.Verify;
+
+namespace aweXpect;
+
+public static partial class ThatMockVerify
+{
+	/// <summary>
+	///     Verifies that all interactions on the mock have been verified.
+	/// </summary>
+	public static AndOrResult<IMockVerify<TVerify>, IThat<IMockVerify<TVerify>>>
+		AllInteractionsAreVerified<TVerify>(
+			this IThat<IMockVerify<TVerify>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((_, _, grammars)
+				=> new AllInteractionsAreVerifiedConstraint<TVerify>(grammars)),
+			subject);
+
+	private sealed class AllInteractionsAreVerifiedConstraint<TVerify>(
+		ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<IMockVerify<TVerify>>(grammars),
+			IValueConstraint<IMockVerify<TVerify>>
+	{
+		public ConstraintResult IsMetBy(IMockVerify<TVerify> actual)
+		{
+			Actual = actual;
+			Outcome = actual.ThatAllInteractionsAreVerified()
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has all interactions verified");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is IHasMockRegistration mockRegistration)
+			{
+				IReadOnlyCollection<IInteraction> missingInteractions =
+					mockRegistration.Registrations.Interactions.GetUnverifiedInteractions();
+				stringBuilder.Append("the following ");
+				if (missingInteractions.Count == 1)
+				{
+					stringBuilder.Append("interaction was not verified:");
+				}
+				else
+				{
+					stringBuilder.Append(missingInteractions.Count)
+						.Append(" interactions were not verified:");
+				}
+
+				stringBuilder.AppendLine().Append(" - ");
+				stringBuilder.Append(string.Join($"{Environment.NewLine} - ", missingInteractions));
+			}
+			else
+			{
+				stringBuilder.Append("not all were");
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has not all interactions verified");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all were");
+
+		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
+		{
+			if (typeof(TValue) == typeof(IDescribableSubject) &&
+			    new MyDescribableSubject<TVerify>() is TValue describableSubject)
+			{
+				value = describableSubject;
+				return true;
+			}
+
+			return base.TryGetValue(out value);
+		}
+	}
+}

--- a/Source/aweXpect.Mockolate/ThatMockVerify.cs
+++ b/Source/aweXpect.Mockolate/ThatMockVerify.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using Mockolate.Verify;
+
+namespace aweXpect;
+
+/// <summary>
+///     Expectations on the <see cref="IMockVerify{TVerify}" /> returned from a mockolate Mock.
+/// </summary>
+public static partial class ThatMockVerify;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
 using Mockolate.Verify;
 
 namespace aweXpect;
@@ -228,24 +228,6 @@ public static partial class ThatVerificationResult
 			}
 
 			return base.TryGetValue(out value);
-		}
-	}
-
-	private sealed class MyDescribableSubject<TVerify> : IDescribableSubject
-	{
-		public string GetDescription()
-		{
-			var mockVerify = Formatter.Format(typeof(TVerify));
-			if (mockVerify.StartsWith("MockVerify", StringComparison.Ordinal))
-			{
-				mockVerify = $"Mock{mockVerify.Substring("MockVerify".Length)}";
-				var genericSeparator = mockVerify.IndexOf(", ");
-				if (genericSeparator > 0)
-				{
-					mockVerify = $"{mockVerify.Substring(0, genericSeparator)}>";
-				}
-			}
-			return $"the {mockVerify} mock";
 		}
 	}
 

--- a/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net10.0.txt
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net10.0.txt
@@ -2,6 +2,10 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
 namespace aweXpect
 {
+    public static class ThatMockVerify
+    {
+        public static aweXpect.Results.AndOrResult<Mockolate.Verify.IMockVerify<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>>> AllInteractionsAreVerified<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>> subject) { }
+    }
     public static class ThatVerificationResult
     {
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> AtLeast<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject, aweXpect.Core.Times times) { }

--- a/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net8.0.txt
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net8.0.txt
@@ -2,6 +2,10 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace aweXpect
 {
+    public static class ThatMockVerify
+    {
+        public static aweXpect.Results.AndOrResult<Mockolate.Verify.IMockVerify<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>>> AllInteractionsAreVerified<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>> subject) { }
+    }
     public static class ThatVerificationResult
     {
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> AtLeast<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject, aweXpect.Core.Times times) { }

--- a/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_netstandard2.0.txt
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_netstandard2.0.txt
@@ -2,6 +2,10 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace aweXpect
 {
+    public static class ThatMockVerify
+    {
+        public static aweXpect.Results.AndOrResult<Mockolate.Verify.IMockVerify<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>>> AllInteractionsAreVerified<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>> subject) { }
+    }
     public static class ThatVerificationResult
     {
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> AtLeast<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject, aweXpect.Core.Times times) { }

--- a/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllInteractionsAreVerifiedTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllInteractionsAreVerifiedTests.cs
@@ -1,0 +1,102 @@
+﻿using Mockolate;
+using Mockolate.Verify;
+using Xunit.Sdk;
+
+namespace aweXpect.Mockolate.Tests;
+
+public sealed partial class ThatMockVerifyIs
+{
+	public sealed class AllInteractionsAreVerifiedTests
+	{
+		[Fact]
+		public async Task WhenAllInvocationsWereVerified_ShouldNotThrow()
+		{
+			IMyService mock = Mock.Create<IMyService>();
+
+			mock.DoWork(1);
+			mock.DoWork(2);
+
+			mock.VerifyMock.Invoked.DoWork(Match.Any<int>()).AtLeastOnce();
+
+			async Task Act()
+			{
+				await That(mock.VerifyMock).AllInteractionsAreVerified();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenOneInvocationIsNotVerified_ShouldThrow()
+		{
+			IMyService mock = Mock.Create<IMyService>();
+
+			mock.DoWork(1);
+			mock.DoWork(2);
+
+			mock.VerifyMock.Invoked.DoWork(Match.With(1)).AtLeastOnce();
+
+			async Task Act()
+			{
+				await That(mock.VerifyMock).AllInteractionsAreVerified();
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the ThatMockVerifyIs.IMyService mock
+				             has all interactions verified,
+				             but the following interaction was not verified:
+				              - [1] invoke method aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(2)
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenMultipleInvocationIsNotVerified_ShouldThrow()
+		{
+			IMyService mock = Mock.Create<IMyService>();
+
+			mock.DoWork(1);
+			mock.DoWork(2);
+			mock.DoWork(3);
+
+			mock.VerifyMock.Invoked.DoWork(Match.With(2)).AtLeastOnce();
+
+			async Task Act()
+			{
+				await That(mock.VerifyMock).AllInteractionsAreVerified();
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the ThatMockVerifyIs.IMyService mock
+				             has all interactions verified,
+				             but the following 2 interactions were not verified:
+				              - [0] invoke method aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(1)
+				              - [2] invoke method aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(3)
+				             """);
+		}
+
+		[Fact]
+		public async Task Negated_WhenAllAreVerified_ShouldThrow()
+		{
+			IMyService mock = Mock.Create<IMyService>();
+
+			mock.DoWork(1);
+			mock.DoWork(2);
+
+			mock.VerifyMock.Invoked.DoWork(Match.Any<int>()).AtLeastOnce();
+
+			async Task Act()
+			{
+				await That(mock.VerifyMock).DoesNotComplyWith(it => it.AllInteractionsAreVerified());
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the ThatMockVerifyIs.IMyService mock
+				             has not all interactions verified,
+				             but all were
+				             """);
+		}
+	}
+}

--- a/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.cs
@@ -1,0 +1,9 @@
+﻿namespace aweXpect.Mockolate.Tests;
+
+public sealed partial class ThatMockVerifyIs
+{
+	public interface IMyService
+	{
+		void DoWork(int value);
+	}
+}


### PR DESCRIPTION
This PR adds a new `AllInteractionsAreVerified` assertion method for the Mockolate mocking library integration. This method verifies that all mock interactions have been properly verified in tests.

### Key changes:
- Introduced `ThatMockVerify` extension class with `AllInteractionsAreVerified` method
- Refactored `MyDescribableSubject` into a shared helper class
- Updated Mockolate dependency to version 0.36.0

---

- *Fixes #18*