### PR TITLE
feat: add `Times` extension

### DIFF
--- a/Source/aweXpect.Mockolate/Helpers/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/Source/aweXpect.Mockolate/Helpers/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -1,0 +1,33 @@
+﻿#if !NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+	/// <summary>
+	///     Indicates that a parameter captures the expression passed for another parameter as a string.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Parameter)]
+	[ExcludeFromCodeCoverage]
+	internal sealed class CallerArgumentExpressionAttribute : Attribute
+	{
+		/// <summary>
+		///     Initializes a new instance of the <see cref="CallerArgumentExpressionAttribute" /> class.
+		/// </summary>
+		/// <param name="parameterName">The name of the parameter whose expression should be captured as a string.</param>
+		public CallerArgumentExpressionAttribute(string parameterName)
+		{
+			ParameterName = parameterName;
+		}
+
+		/// <summary>
+		///     Gets the name of the parameter whose expression should be captured as a string.
+		/// </summary>
+		public string ParameterName { get; }
+	}
+}
+
+#endif

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Times.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Times.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+using Mockolate.Verify;
+
+namespace aweXpect;
+
+public static partial class ThatVerificationResult
+{
+	/// <summary>
+	///     Verifies that the checked interaction happened according to the <paramref name="predicate" />.
+	/// </summary>
+	public static AndOrResult<VerificationResult<TVerify>, IThat<VerificationResult<TVerify>>> Times<TVerify>(
+		this IThat<VerificationResult<TVerify>> subject, Func<int, bool> predicate,
+		[CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+		=> new(subject.Get()
+				.ExpectationBuilder.AddConstraint((expectationBuilder, it, grammars)
+					=> new TimesConstraint<TVerify>(expectationBuilder, it, grammars, predicate,
+						doNotPopulateThisValue)),
+			subject);
+
+	private sealed class TimesConstraint<TVerify>(
+		ExpectationBuilder expectationBuilder,
+		string it,
+		ExpectationGrammars grammars,
+		Func<int, bool> predicate,
+		string predicateExpression)
+		: ConstraintResult.WithValue<VerificationResult<TVerify>>(grammars),
+			IValueConstraint<VerificationResult<TVerify>>
+	{
+		private int _count = -1;
+		private string _expectation = "";
+
+		public ConstraintResult IsMetBy(VerificationResult<TVerify> actual)
+		{
+			IVerificationResult result = actual;
+			_expectation = result.Expectation;
+			Actual = actual;
+			Outcome = result.Verify(interactions =>
+			{
+				string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
+				expectationBuilder.UpdateContexts(contexts => contexts.Add(
+					new ResultContext.SyncCallback("Interactions", () => context)));
+				_count = interactions.Length;
+				return predicate(_count);
+			})
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(_expectation).Append(" according to the predicate ").Append(predicateExpression);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (_count == 0)
+			{
+				stringBuilder.Append("never found ").Append(it);
+			}
+			else
+			{
+				stringBuilder.Append("found ").Append(it).Append(' ').Append(_count.ToAmountString());
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(_expectation).Append(" not according to the predicate ")
+				.Append(predicateExpression);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+
+		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
+		{
+			if (typeof(TValue) == typeof(IDescribableSubject) &&
+			    new MyDescribableSubject<TVerify>() is TValue describableSubject)
+			{
+				value = describableSubject;
+				return true;
+			}
+
+			return base.TryGetValue(out value);
+		}
+	}
+}

--- a/Tests/aweXpect.Mockolate.Api.Tests/ApiAcceptance.cs
+++ b/Tests/aweXpect.Mockolate.Api.Tests/ApiAcceptance.cs
@@ -1,4 +1,4 @@
-﻿namespace aweXpect.Api.Tests;
+﻿namespace aweXpect.Mockolate.Api.Tests;
 
 public sealed class ApiAcceptance
 {

--- a/Tests/aweXpect.Mockolate.Api.Tests/ApiApprovalTests.cs
+++ b/Tests/aweXpect.Mockolate.Api.Tests/ApiApprovalTests.cs
@@ -1,4 +1,4 @@
-﻿namespace aweXpect.Api.Tests;
+﻿namespace aweXpect.Mockolate.Api.Tests;
 
 /// <summary>
 ///     Whenever a test fails, this means that the public API surface changed.

--- a/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net10.0.txt
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net10.0.txt
@@ -19,6 +19,7 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Never<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Once<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<T>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<T>>> Then<T>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<T>> subject, params System.Func<Mockolate.Verify.IMockVerify<T>, Mockolate.Verify.VerificationResult<T>>[] interactions) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Times<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject, System.Func<int, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Twice<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject) { }
     }
 }

--- a/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net8.0.txt
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net8.0.txt
@@ -19,6 +19,7 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Never<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Once<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<T>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<T>>> Then<T>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<T>> subject, params System.Func<Mockolate.Verify.IMockVerify<T>, Mockolate.Verify.VerificationResult<T>>[] interactions) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Times<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject, System.Func<int, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Twice<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject) { }
     }
 }

--- a/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_netstandard2.0.txt
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_netstandard2.0.txt
@@ -19,6 +19,7 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Never<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Once<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject) { }
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<T>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<T>>> Then<T>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<T>> subject, params System.Func<Mockolate.Verify.IMockVerify<T>, Mockolate.Verify.VerificationResult<T>>[] interactions) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Times<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject, System.Func<int, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.VerificationResult<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>>> Twice<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.VerificationResult<TVerify>> subject) { }
     }
 }

--- a/Tests/aweXpect.Mockolate.Api.Tests/Helper.cs
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Helper.cs
@@ -7,7 +7,7 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using PublicApiGenerator;
 
-namespace aweXpect.Api.Tests;
+namespace aweXpect.Mockolate.Api.Tests;
 
 public static class Helper
 {

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
@@ -1,0 +1,88 @@
+using Mockolate;
+using Xunit.Sdk;
+
+namespace aweXpect.Mockolate.Tests;
+
+public sealed partial class ThatVerificationResultIs
+{
+	public sealed class TimesTests
+	{
+		[Theory]
+		[InlineData(0, true)]
+		[InlineData(1, false)]
+		[InlineData(2, true)]
+		[InlineData(3, false)]
+		[InlineData(4, true)]
+		[InlineData(5, false)]
+		public async Task Times_WithEvenPredicate_ShouldReturnExpectedResult(int count, bool expectSuccess)
+		{
+			IMyService mock = Mock.Create<IMyService>();
+			for (int i = 0; i < count; i++)
+			{
+				mock.MyMethod(1, false);
+			}
+
+			async Task Act()
+			{
+				await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Times(n => n % 2 == 0);
+			}
+
+			string expectedFoundTimes = count switch
+			{
+				0 => "never found it",
+				1 => "found it once",
+				2 => "found it twice",
+				_ => $"found it {count} times",
+			};
+
+			await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
+				.WithMessage($"""
+				              Expected that the ThatVerificationResultIs.IMyService mock
+				              invoked method MyMethod(1, false) according to the predicate n => n % 2 == 0,
+				              but {expectedFoundTimes}
+
+				              Interactions:
+				              [*]
+				              """).AsWildcard();
+		}
+
+		[Theory]
+		[InlineData(0, false)]
+		[InlineData(1, true)]
+		[InlineData(2, false)]
+		[InlineData(3, true)]
+		[InlineData(4, false)]
+		[InlineData(5, true)]
+		public async Task Times_WithOddPredicate_ShouldReturnExpectedResult(int count, bool expectSuccess)
+		{
+			IMyService mock = Mock.Create<IMyService>();
+			for (int i = 0; i < count; i++)
+			{
+				mock.MyMethod(1, false);
+			}
+
+			async Task Act()
+			{
+				await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Times(n => n % 2 == 1);
+			}
+
+			string expectedFoundTimes = count switch
+			{
+				0 => "never found it",
+				1 => "found it once",
+				2 => "found it twice",
+				_ => $"found it {count} times",
+			};
+
+			await That(Act).Throws<XunitException>().OnlyIf(!expectSuccess)
+				.WithMessage($"""
+				              Expected that the ThatVerificationResultIs.IMyService mock
+				              invoked method MyMethod(1, false) according to the predicate n => n % 2 == 1,
+				              but {expectedFoundTimes}
+
+				              Interactions:
+				              [*]
+				              """).AsWildcard();
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new `Times` extension method that enables verification of mock interactions using custom predicates. The method accepts a predicate function to evaluate the number of times a mock interaction occurred, providing more flexible verification than the existing fixed count methods (`Once`, `Twice`, `Never`).

### Key Changes:
- Added `Times` extension method with predicate-based verification
- Added polyfill for `CallerArgumentExpression` attribute for .NET Standard 2.0 compatibility
- Fixed incorrect namespace declarations in test files