### PR TITLE
chore: bump Mockolate to v0.38.1

### DIFF
--- a/Benchmarks/aweXpect.Mockolate.Benchmarks/aweXpect.Mockolate.Benchmarks.csproj
+++ b/Benchmarks/aweXpect.Mockolate.Benchmarks/aweXpect.Mockolate.Benchmarks.csproj
@@ -2,9 +2,10 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<LangVersion>latest</LangVersion>
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	</PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.29.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.26.0" />
-		<PackageVersion Include="Mockolate" Version="0.36.0" />
+		<PackageVersion Include="Mockolate" Version="0.38.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />


### PR DESCRIPTION
This PR updates the Mockolate dependency from version 0.36.0 to 0.38.1 and upgrades the benchmark project's target framework from .NET 8.0 to .NET 10.0.

- Updated Mockolate package version to 0.38.1
- Upgraded benchmark project to target .NET 10.0
- Added explicit LangVersion setting to benchmark project