### PR TITLE
feat: add `AllSetupsAreUsed`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.29.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.26.0" />
-		<PackageVersion Include="Mockolate" Version="0.38.1" />
+		<PackageVersion Include="Mockolate" Version="0.40.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />

--- a/Source/aweXpect.Mockolate/ThatMockVerify.AllSetupsAreUsed.cs
+++ b/Source/aweXpect.Mockolate/ThatMockVerify.AllSetupsAreUsed.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+using Mockolate;
+using Mockolate.Setup;
+using Mockolate.Verify;
+
+namespace aweXpect;
+
+public static partial class ThatMockVerify
+{
+	/// <summary>
+	///     Verifies that all setups on the mock have been used.
+	/// </summary>
+	public static AndOrResult<IMockVerify<TVerify>, IThat<IMockVerify<TVerify>>>
+		AllSetupsAreUsed<TVerify>(
+			this IThat<IMockVerify<TVerify>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((_, _, grammars)
+				=> new AllSetupsAreUsedConstraint<TVerify>(grammars)),
+			subject);
+
+	private sealed class AllSetupsAreUsedConstraint<TVerify>(
+		ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<IMockVerify<TVerify>>(grammars),
+			IValueConstraint<IMockVerify<TVerify>>
+	{
+		public ConstraintResult IsMetBy(IMockVerify<TVerify> actual)
+		{
+			Actual = actual;
+			Outcome = actual.ThatAllSetupsAreUsed()
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has used all setups");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (Actual is IHasMockRegistration mockRegistration)
+			{
+				IReadOnlyCollection<ISetup> unusedSetups =
+					mockRegistration.Registrations.GetUnusedSetups(mockRegistration.Registrations.Interactions);
+				stringBuilder.Append("the following ");
+				if (unusedSetups.Count == 1)
+				{
+					stringBuilder.Append("setup was not used:");
+				}
+				else
+				{
+					stringBuilder.Append(unusedSetups.Count)
+						.Append(" setups were not used:");
+				}
+
+				stringBuilder.AppendLine().Append(" - ");
+				stringBuilder.Append(string.Join($"{Environment.NewLine} - ", unusedSetups));
+			}
+			else
+			{
+				stringBuilder.Append("not all were");
+			}
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has not used all setups");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all were");
+
+		public override bool TryGetValue<TValue>([NotNullWhen(true)] out TValue? value) where TValue : default
+		{
+			if (typeof(TValue) == typeof(IDescribableSubject) &&
+			    new MyDescribableSubject<TVerify>() is TValue describableSubject)
+			{
+				value = describableSubject;
+				return true;
+			}
+
+			return base.TryGetValue(out value);
+		}
+	}
+}

--- a/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net10.0.txt
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net10.0.txt
@@ -5,6 +5,7 @@ namespace aweXpect
     public static class ThatMockVerify
     {
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.IMockVerify<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>>> AllInteractionsAreVerified<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>> subject) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Verify.IMockVerify<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>>> AllSetupsAreUsed<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>> subject) { }
     }
     public static class ThatVerificationResult
     {

--- a/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net8.0.txt
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_net8.0.txt
@@ -5,6 +5,7 @@ namespace aweXpect
     public static class ThatMockVerify
     {
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.IMockVerify<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>>> AllInteractionsAreVerified<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>> subject) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Verify.IMockVerify<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>>> AllSetupsAreUsed<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>> subject) { }
     }
     public static class ThatVerificationResult
     {

--- a/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_netstandard2.0.txt
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Expected/aweXpect.Mockolate_netstandard2.0.txt
@@ -5,6 +5,7 @@ namespace aweXpect
     public static class ThatMockVerify
     {
         public static aweXpect.Results.AndOrResult<Mockolate.Verify.IMockVerify<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>>> AllInteractionsAreVerified<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>> subject) { }
+        public static aweXpect.Results.AndOrResult<Mockolate.Verify.IMockVerify<TVerify>, aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>>> AllSetupsAreUsed<TVerify>(this aweXpect.Core.IThat<Mockolate.Verify.IMockVerify<TVerify>> subject) { }
     }
     public static class ThatVerificationResult
     {

--- a/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllSetupsAreUsedTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllSetupsAreUsedTests.cs
@@ -1,0 +1,98 @@
+﻿using Mockolate;
+using Mockolate.Verify;
+using Xunit.Sdk;
+
+namespace aweXpect.Mockolate.Tests;
+
+public sealed partial class ThatMockVerifyIs
+{
+	public sealed class AllSetupsAreUsedTests
+	{
+		[Fact]
+		public async Task WhenAllInvocationsWereVerified_ShouldNotThrow()
+		{
+			IMyService mock = Mock.Create<IMyService>();
+			mock.SetupMock.Method.DoWork(Match.Any<int>());
+
+			mock.DoWork(1);
+			mock.DoWork(2);
+
+			async Task Act()
+			{
+				await That(mock.VerifyMock).AllSetupsAreUsed();
+			}
+
+			await That(Act).DoesNotThrow();
+		}
+
+		[Fact]
+		public async Task WhenOneSetupIsNotUsed_ShouldThrow()
+		{
+			IMyService mock = Mock.Create<IMyService>();
+			mock.SetupMock.Method.DoWork(Match.With(1));
+			mock.SetupMock.Method.DoWork(Match.With(2));
+
+			mock.DoWork(1);
+
+			async Task Act()
+			{
+				await That(mock.VerifyMock).AllSetupsAreUsed();
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the ThatMockVerifyIs.IMyService mock
+				             has used all setups,
+				             but the following setup was not used:
+				              - void aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(2 value)
+				             """);
+		}
+
+		[Fact]
+		public async Task WhenMultipleSetupsAreNotUsed_ShouldThrow()
+		{
+			IMyService mock = Mock.Create<IMyService>();
+			mock.SetupMock.Method.DoWork(Match.With(1));
+			mock.SetupMock.Method.DoWork(Match.With(2));
+			mock.SetupMock.Method.DoWork(Match.With(3));
+
+			mock.DoWork(2);
+
+			async Task Act()
+			{
+				await That(mock.VerifyMock).AllSetupsAreUsed();
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the ThatMockVerifyIs.IMyService mock
+				             has used all setups,
+				             but the following 2 setups were not used:
+				              - void aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(3 value)
+				              - void aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(1 value)
+				             """);
+		}
+
+		[Fact]
+		public async Task Negated_WhenAllSetupsAreUsed_ShouldThrow()
+		{
+			IMyService mock = Mock.Create<IMyService>();
+			mock.SetupMock.Method.DoWork(Match.Any<int>());
+
+			mock.DoWork(1);
+			mock.DoWork(2);
+
+			async Task Act()
+			{
+				await That(mock.VerifyMock).DoesNotComplyWith(it => it.AllSetupsAreUsed());
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the ThatMockVerifyIs.IMyService mock
+				             has not used all setups,
+				             but all were
+				             """);
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new `AllSetupsAreUsed` verification method to the aweXpect.Mockolate library. This feature allows users to verify that all mocked method setups have been invoked during testing.

### Key changes
- Adds `AllSetupsAreUsed` extension method for mock verification
- Updates the Mockolate package dependency from 0.38.1 to 0.40.0
- Includes comprehensive test coverage for success, single failure, multiple failures, and negated scenarios

---

- *Fixes #18*