### PR TITLE
chore: bump Mockolate to v0.41.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.29.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.26.0" />
-		<PackageVersion Include="Mockolate" Version="0.40.0" />
+		<PackageVersion Include="Mockolate" Version="0.41.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ mock.MyMethod(3);
 mock.MyMethod(4);
 
 // Verifies MyMethod(1), then MyMethod(2), then MyMethod(4) were called in order
-await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1))).Then(
-    m => m.Invoked.MyMethod(Match.With(2)),
-    m => m.Invoked.MyMethod(Match.With(4))
+await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1))).Then(
+    m => m.Invoked.MyMethod(It.Is(2)),
+    m => m.Invoked.MyMethod(It.Is(4))
 );
 ```
 

--- a/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllInteractionsAreVerifiedTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllInteractionsAreVerifiedTests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatMockVerifyIs
 			mock.DoWork(1);
 			mock.DoWork(2);
 
-			mock.VerifyMock.Invoked.DoWork(Match.Any<int>()).AtLeastOnce();
+			mock.VerifyMock.Invoked.DoWork(It.IsAny<int>()).AtLeastOnce();
 
 			async Task Act()
 			{
@@ -34,7 +34,7 @@ public sealed partial class ThatMockVerifyIs
 			mock.DoWork(1);
 			mock.DoWork(2);
 
-			mock.VerifyMock.Invoked.DoWork(Match.With(1)).AtLeastOnce();
+			mock.VerifyMock.Invoked.DoWork(It.Is(1)).AtLeastOnce();
 
 			async Task Act()
 			{
@@ -59,7 +59,7 @@ public sealed partial class ThatMockVerifyIs
 			mock.DoWork(2);
 			mock.DoWork(3);
 
-			mock.VerifyMock.Invoked.DoWork(Match.With(2)).AtLeastOnce();
+			mock.VerifyMock.Invoked.DoWork(It.Is(2)).AtLeastOnce();
 
 			async Task Act()
 			{
@@ -84,7 +84,7 @@ public sealed partial class ThatMockVerifyIs
 			mock.DoWork(1);
 			mock.DoWork(2);
 
-			mock.VerifyMock.Invoked.DoWork(Match.Any<int>()).AtLeastOnce();
+			mock.VerifyMock.Invoked.DoWork(It.IsAny<int>()).AtLeastOnce();
 
 			async Task Act()
 			{

--- a/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllSetupsAreUsedTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllSetupsAreUsedTests.cs
@@ -12,7 +12,7 @@ public sealed partial class ThatMockVerifyIs
 		public async Task WhenAllInvocationsWereVerified_ShouldNotThrow()
 		{
 			IMyService mock = Mock.Create<IMyService>();
-			mock.SetupMock.Method.DoWork(Match.Any<int>());
+			mock.SetupMock.Method.DoWork(It.IsAny<int>());
 
 			mock.DoWork(1);
 			mock.DoWork(2);
@@ -29,8 +29,8 @@ public sealed partial class ThatMockVerifyIs
 		public async Task WhenOneSetupIsNotUsed_ShouldThrow()
 		{
 			IMyService mock = Mock.Create<IMyService>();
-			mock.SetupMock.Method.DoWork(Match.With(1));
-			mock.SetupMock.Method.DoWork(Match.With(2));
+			mock.SetupMock.Method.DoWork(It.Is(1));
+			mock.SetupMock.Method.DoWork(It.Is(2));
 
 			mock.DoWork(1);
 
@@ -44,7 +44,7 @@ public sealed partial class ThatMockVerifyIs
 				             Expected that the ThatMockVerifyIs.IMyService mock
 				             has used all setups,
 				             but the following setup was not used:
-				              - void aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(2 value)
+				              - void aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(2)
 				             """);
 		}
 
@@ -52,9 +52,9 @@ public sealed partial class ThatMockVerifyIs
 		public async Task WhenMultipleSetupsAreNotUsed_ShouldThrow()
 		{
 			IMyService mock = Mock.Create<IMyService>();
-			mock.SetupMock.Method.DoWork(Match.With(1));
-			mock.SetupMock.Method.DoWork(Match.With(2));
-			mock.SetupMock.Method.DoWork(Match.With(3));
+			mock.SetupMock.Method.DoWork(It.Is(1));
+			mock.SetupMock.Method.DoWork(It.Is(2));
+			mock.SetupMock.Method.DoWork(It.Is(3));
 
 			mock.DoWork(2);
 
@@ -68,8 +68,8 @@ public sealed partial class ThatMockVerifyIs
 				             Expected that the ThatMockVerifyIs.IMyService mock
 				             has used all setups,
 				             but the following 2 setups were not used:
-				              - void aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(3 value)
-				              - void aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(1 value)
+				              - void aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(3)
+				              - void aweXpect.Mockolate.Tests.ThatMockVerifyIs.IMyService.DoWork(1)
 				             """);
 		}
 
@@ -77,7 +77,7 @@ public sealed partial class ThatMockVerifyIs
 		public async Task Negated_WhenAllSetupsAreUsed_ShouldThrow()
 		{
 			IMyService mock = Mock.Create<IMyService>();
-			mock.SetupMock.Method.DoWork(Match.Any<int>());
+			mock.SetupMock.Method.DoWork(It.IsAny<int>());
 
 			mock.DoWork(1);
 			mock.DoWork(2);

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastOnceTests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeastOnce();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeastOnce();
 
 			await That(Act).DoesNotThrow();
 		}
@@ -31,7 +31,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeastOnce();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeastOnce();
 
 			await That(Act).DoesNotThrow();
 		}
@@ -42,7 +42,7 @@ public sealed partial class ThatVerificationResultIs
 			var mock = Mock.Create<IMyService>();
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeastOnce();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeastOnce();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -63,7 +63,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeastOnce();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeastOnce();
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatVerificationResultIs
 			var mock = Mock.Create<IMyService>();
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeast(times);
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeast(times);
 
 			await That(Act).Throws<XunitException>().OnlyIf(shouldThrow)
 				.WithMessage($"""
@@ -42,7 +42,7 @@ public sealed partial class ThatVerificationResultIs
 			}
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeast(times);
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeast(times);
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage($"""
@@ -70,7 +70,7 @@ public sealed partial class ThatVerificationResultIs
 			}
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeast(times);
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeast(times);
 
 			await That(Act).DoesNotThrow();
 		}
@@ -89,7 +89,7 @@ public sealed partial class ThatVerificationResultIs
 			}
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeast(times);
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeast(times);
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTwiceTests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeastTwice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeastTwice();
 
 			await That(Act).DoesNotThrow();
 		}
@@ -30,7 +30,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeastTwice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeastTwice();
 
 			await That(Act).DoesNotThrow();
 		}
@@ -41,7 +41,7 @@ public sealed partial class ThatVerificationResultIs
 			var mock = Mock.Create<IMyService>();
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeastTwice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeastTwice();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -62,7 +62,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtLeastTwice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtLeastTwice();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostOnceTests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtMostOnce();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtMostOnce();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -41,7 +41,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtMostOnce();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtMostOnce();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -64,7 +64,7 @@ public sealed partial class ThatVerificationResultIs
 			var mock = Mock.Create<IMyService>();
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtMostOnce();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtMostOnce();
 
 			await That(Act).DoesNotThrow();
 		}
@@ -77,7 +77,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtMostOnce();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtMostOnce();
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTests.cs
@@ -21,7 +21,7 @@ public sealed partial class ThatVerificationResultIs
 			}
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtMost(times);
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtMost(times);
 
 			await That(Act).DoesNotThrow();
 		}
@@ -39,7 +39,7 @@ public sealed partial class ThatVerificationResultIs
 			}
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtMost(times);
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtMost(times);
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage($"""
@@ -68,7 +68,7 @@ public sealed partial class ThatVerificationResultIs
 			}
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtMost(times);
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtMost(times);
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTwiceTests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtMostTwice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtMostTwice();
 
 			await That(Act).DoesNotThrow();
 		}
@@ -30,7 +30,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtMostTwice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtMostTwice();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -53,7 +53,7 @@ public sealed partial class ThatVerificationResultIs
 			var mock = Mock.Create<IMyService>();
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtMostTwice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtMostTwice();
 
 			await That(Act).DoesNotThrow();
 		}
@@ -66,7 +66,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).AtMostTwice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).AtMostTwice();
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.BetweenTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.BetweenTests.cs
@@ -23,7 +23,7 @@ public sealed partial class ThatVerificationResultIs
 
 			async Task Act()
 			{
-				await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Between(minimum).And(maximum);
+				await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Between(minimum).And(maximum);
 			}
 
 			await That(Act).DoesNotThrow();
@@ -39,7 +39,7 @@ public sealed partial class ThatVerificationResultIs
 
 			async Task Act()
 			{
-				await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Between(minimum).And(maximum);
+				await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Between(minimum).And(maximum);
 			}
 
 			await That(Act).Throws<XunitException>().OnlyIf(shouldThrow)
@@ -67,7 +67,7 @@ public sealed partial class ThatVerificationResultIs
 
 			async Task Act()
 			{
-				await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Between(minimum).And(maximum);
+				await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Between(minimum).And(maximum);
 			}
 
 			await That(Act).Throws<XunitException>()
@@ -97,7 +97,7 @@ public sealed partial class ThatVerificationResultIs
 
 			async Task Act()
 			{
-				await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Between(minimum).And(maximum);
+				await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Between(minimum).And(maximum);
 			}
 
 			await That(Act).Throws<XunitException>()

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ExactlyTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ExactlyTests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatVerificationResultIs
 			var mock = Mock.Create<IMyService>();
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Exactly(times);
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Exactly(times);
 
 			await That(Act).Throws<XunitException>().OnlyIf(shouldThrow)
 				.WithMessage($"""
@@ -42,7 +42,7 @@ public sealed partial class ThatVerificationResultIs
 			}
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Exactly(times);
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Exactly(times);
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage($"""
@@ -70,7 +70,7 @@ public sealed partial class ThatVerificationResultIs
 			}
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Exactly(times);
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Exactly(times);
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage($"""
@@ -99,7 +99,7 @@ public sealed partial class ThatVerificationResultIs
 			}
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Exactly(times);
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Exactly(times);
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.NeverTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.NeverTests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Never();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Never();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -41,7 +41,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Never();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Never();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -66,7 +66,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Never();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Never();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -87,7 +87,7 @@ public sealed partial class ThatVerificationResultIs
 			var mock = Mock.Create<IMyService>();
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Never();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Never();
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.OnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.OnceTests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Once();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Once();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -41,7 +41,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Once();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Once();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -65,7 +65,7 @@ public sealed partial class ThatVerificationResultIs
 
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Once();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Once();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -86,7 +86,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Once();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Once();
 
 			await That(Act).DoesNotThrow();
 		}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
@@ -17,8 +17,8 @@ public sealed partial class ThatVerificationResultIs
 			sut.MyMethod(3);
 			sut.MyMethod(4);
 
-			await That(sut.VerifyMock.Invoked.MyMethod(Match.With(3))).Then(m => m.Invoked.MyMethod(Match.With(4)));
-			await That(async Task () => await That(sut.VerifyMock.Invoked.MyMethod(Match.With(2))).Then(m => m.Invoked.MyMethod(Match.With(1))))
+			await That(sut.VerifyMock.Invoked.MyMethod(It.Is(3))).Then(m => m.Invoked.MyMethod(It.Is(4)));
+			await That(async Task () => await That(sut.VerifyMock.Invoked.MyMethod(It.Is(2))).Then(m => m.Invoked.MyMethod(It.Is(1))))
 				.Throws<XunitException>()
 				.WithMessage("""
 					Expected that the ThatVerificationResultIs.IMyService mock
@@ -34,7 +34,7 @@ public sealed partial class ThatVerificationResultIs
 					  [3] invoke method aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(4)
 					]
 					""");
-			await That(sut.VerifyMock.Invoked.MyMethod(Match.With(1))).Then(m => m.Invoked.MyMethod(Match.With(2)), m => m.Invoked.MyMethod(Match.With(3)));
+			await That(sut.VerifyMock.Invoked.MyMethod(It.Is(1))).Then(m => m.Invoked.MyMethod(It.Is(2)), m => m.Invoked.MyMethod(It.Is(3)));
 		}
 
 		[Fact]
@@ -47,7 +47,7 @@ public sealed partial class ThatVerificationResultIs
 			sut.MyMethod(3);
 			sut.MyMethod(4);
 
-			await That(async Task () => await That(sut.VerifyMock.Invoked.MyMethod(Match.With(6))).Then(m => m.Invoked.MyMethod(Match.With(4))))
+			await That(async Task () => await That(sut.VerifyMock.Invoked.MyMethod(It.Is(6))).Then(m => m.Invoked.MyMethod(It.Is(4))))
 				.Throws<XunitException>()
 				.WithMessage("""
 					Expected that the ThatVerificationResultIs.IMyService mock
@@ -64,7 +64,7 @@ public sealed partial class ThatVerificationResultIs
 					]
 					""");
 
-			await That(async Task () => await That(sut.VerifyMock.Invoked.MyMethod(Match.With(1))).Then(m => m.Invoked.MyMethod(Match.With(6)), m => m.Invoked.MyMethod(Match.With(3))))
+			await That(async Task () => await That(sut.VerifyMock.Invoked.MyMethod(It.Is(1))).Then(m => m.Invoked.MyMethod(It.Is(6)), m => m.Invoked.MyMethod(It.Is(3))))
 				.Throws<XunitException>()
 				.WithMessage("""
 					Expected that the ThatVerificationResultIs.IMyService mock
@@ -82,7 +82,7 @@ public sealed partial class ThatVerificationResultIs
 					]
 					""");
 
-			await That(async Task () => await That(sut.VerifyMock.Invoked.MyMethod(Match.With(1))).Then(m => m.Invoked.MyMethod(Match.With(2)), m => m.Invoked.MyMethod(Match.With(6))))
+			await That(async Task () => await That(sut.VerifyMock.Invoked.MyMethod(It.Is(1))).Then(m => m.Invoked.MyMethod(It.Is(2)), m => m.Invoked.MyMethod(It.Is(6))))
 				.Throws<XunitException>()
 				.WithMessage("""
 					Expected that the ThatVerificationResultIs.IMyService mock

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
@@ -24,7 +24,7 @@ public sealed partial class ThatVerificationResultIs
 
 			async Task Act()
 			{
-				await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Times(n => n % 2 == 0);
+				await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Times(n => n % 2 == 0);
 			}
 
 			string expectedFoundTimes = count switch
@@ -63,7 +63,7 @@ public sealed partial class ThatVerificationResultIs
 
 			async Task Act()
 			{
-				await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Times(n => n % 2 == 1);
+				await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Times(n => n % 2 == 1);
 			}
 
 			string expectedFoundTimes = count switch

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TwiceTests.cs
@@ -16,7 +16,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Twice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Twice();
 
 			await That(Act).DoesNotThrow();
 		}
@@ -30,7 +30,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Twice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Twice();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -54,7 +54,7 @@ public sealed partial class ThatVerificationResultIs
 
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Twice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Twice();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""
@@ -75,7 +75,7 @@ public sealed partial class ThatVerificationResultIs
 			mock.MyMethod(1, false);
 
 			async Task Act()
-				=> await That(mock.VerifyMock.Invoked.MyMethod(Match.With(1), Match.With(false))).Twice();
+				=> await That(mock.VerifyMock.Invoked.MyMethod(It.Is(1), It.Is(false))).Twice();
 
 			await That(Act).Throws<XunitException>()
 				.WithMessage("""


### PR DESCRIPTION
This PR updates the Mockolate dependency from version 0.40.0 to 0.41.0 and migrates all test code to use the new API syntax (`It.Is`/`It.IsAny` instead of `Match.With`/`Match.Any`).

### Key Changes:
- Updated Mockolate package version to 0.41.0
- Replaced `Match.With()` with `It.Is()` across all test files
- Replaced `Match.Any<T>()` with `It.IsAny<T>()` across all test files