### PR TITLE
chore: update Mockolate to v0.53.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.29.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.26.0" />
-		<PackageVersion Include="Mockolate" Version="0.41.0" />
+		<PackageVersion Include="Mockolate" Version="0.53.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />


### PR DESCRIPTION
This PR updates the Mockolate package dependency from version 0.41.0 to 0.53.0.