### PR TITLE
chore: update Mockolate to v1.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.29.0" />
+		<PackageVersion Include="aweXpect" Version="2.30.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.27.0" />
-		<PackageVersion Include="Mockolate" Version="0.53.0" />
+		<PackageVersion Include="Mockolate" Version="1.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />


### PR DESCRIPTION
This PR updates dependency versions for testing libraries in the project's central package management configuration. The primary change is upgrading Mockolate from version 0.53.0 to 1.0.0, indicating a major version release. Additionally, the aweXpect library is updated from 2.29.0 to 2.30.0.

### Key Changes:
- Updated Mockolate from v0.53.0 to v1.0.0 (major version upgrade)
- Updated aweXpect from v2.29.0 to v2.30.0 (minor version upgrade)