### PR TITLE
chore: bump Mockolate to v1.0.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="aweXpect" Version="2.30.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.27.0" />
-		<PackageVersion Include="Mockolate" Version="1.0.0" />
+		<PackageVersion Include="Mockolate" Version="1.0.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />


### PR DESCRIPTION
This PR updates the Mockolate package dependency from version 1.0.0 to version 1.0.3.