### PR TITLE
chore: bump Mockolate to 2.0.0-pre.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 		<PackageVersion Include="aweXpect" Version="2.31.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.28.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
-		<PackageVersion Include="Mockolate" Version="2.0.0-pre.2" />
+		<PackageVersion Include="Mockolate" Version="2.0.0-pre.6" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />

--- a/Source/aweXpect.Mockolate/ThatMockVerify.AllInteractionsAreVerified.cs
+++ b/Source/aweXpect.Mockolate/ThatMockVerify.AllInteractionsAreVerified.cs
@@ -32,7 +32,7 @@ public static partial class ThatMockVerify
 		public ConstraintResult IsMetBy(IMockVerify<TVerify> actual)
 		{
 			Actual = actual;
-			Outcome = actual is IMock mock && mock.Registrations.Interactions.GetUnverifiedInteractions().Count == 0
+			Outcome = actual is IMock mock && mock.MockRegistry.Interactions.GetUnverifiedInteractions().Count == 0
 				? Outcome.Success
 				: Outcome.Failure;
 			return this;
@@ -46,7 +46,7 @@ public static partial class ThatMockVerify
 			if (Actual is IMock mock)
 			{
 				IReadOnlyCollection<IInteraction> missingInteractions =
-					mock.Registrations.Interactions.GetUnverifiedInteractions();
+					mock.MockRegistry.Interactions.GetUnverifiedInteractions();
 				stringBuilder.Append("the following ");
 				if (missingInteractions.Count == 1)
 				{

--- a/Source/aweXpect.Mockolate/ThatMockVerify.AllSetupsAreUsed.cs
+++ b/Source/aweXpect.Mockolate/ThatMockVerify.AllSetupsAreUsed.cs
@@ -32,7 +32,7 @@ public static partial class ThatMockVerify
 		public ConstraintResult IsMetBy(IMockVerify<TVerify> actual)
 		{
 			Actual = actual;
-			Outcome = actual is IMock mock && mock.Registrations.GetUnusedSetups(mock.Registrations.Interactions).Count == 0
+			Outcome = actual is IMock mock && mock.MockRegistry.GetUnusedSetups(mock.MockRegistry.Interactions).Count == 0
 				? Outcome.Success
 				: Outcome.Failure;
 			return this;
@@ -46,7 +46,7 @@ public static partial class ThatMockVerify
 			if (Actual is IMock mock)
 			{
 				IReadOnlyCollection<ISetup> unusedSetups =
-					mock.Registrations.GetUnusedSetups(mock.Registrations.Interactions);
+					mock.MockRegistry.GetUnusedSetups(mock.MockRegistry.Interactions);
 				stringBuilder.Append("the following ");
 				if (unusedSetups.Count == 1)
 				{


### PR DESCRIPTION
Updates the `aweXpect.Mockolate` integration to align with the newer Mockolate prerelease, reflecting API changes in the Mockolate mock registry surface.

**Changes:**
- Bump Mockolate dependency from `2.0.0-pre.2` to `2.0.0-pre.6` (central package management).
- Update mock verification constraints to use renamed `mock.MockRegistry` instead of `mock.Registrations` for interaction/setup tracking.

---

- *Part of #78*