### PR TITLE
chore: bump Mockolate to latest pre-release version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 		<PackageVersion Include="aweXpect" Version="2.31.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.28.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
-		<PackageVersion Include="Mockolate" Version="2.0.0-pre.6" />
+		<PackageVersion Include="Mockolate" Version="2.0.0-pre.7" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />


### PR DESCRIPTION
This PR updates the repository’s centrally-managed NuGet dependency on Mockolate to the latest pre-release (v2.0.0-pre.7), aligning downstream projects/tests with the updated Mockolate package.

**Changes:**
- Bump `Mockolate` package version from `2.0.0-pre.6` to `2.0.0-pre.7` in central package management.

---

- *Part of #78*