### PR TITLE
fix: failure message when using `Within`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 		<PackageVersion Include="aweXpect" Version="2.31.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.28.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
-		<PackageVersion Include="Mockolate" Version="2.0.0-pre.7" />
+		<PackageVersion Include="Mockolate" Version="2.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />

--- a/Source/aweXpect.Mockolate/ThatMockVerify.cs
+++ b/Source/aweXpect.Mockolate/ThatMockVerify.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
-using aweXpect.Core;
-using aweXpect.Core.Constraints;
-using Mockolate.Verify;
+﻿using Mockolate.Verify;
 
 namespace aweXpect;
 

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Between.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Between.cs
@@ -86,16 +86,12 @@ public static partial class ThatVerificationResult
 				}
 				catch (MockVerificationTimeoutException)
 				{
-					if (actual is IVerificationResult verificationResult)
-					{
-						string interactionsText = Formatter.Format(verificationResult.MockInteractions.Interactions,
-							FormattingOptions.MultipleLines);
-						expectationBuilder.UpdateContexts(contexts => contexts
-							.Remove("Interactions")
-							.Add(new ResultContext.SyncCallback("Interactions",
-								() => interactionsText)));
-					}
-
+					string interactionsText = Formatter.Format(((IVerificationResult)actual).MockInteractions.Interactions,
+						FormattingOptions.MultipleLines);
+					expectationBuilder.UpdateContexts(contexts => contexts
+						.Remove("Interactions")
+						.Add(new ResultContext.SyncCallback("Interactions",
+							() => interactionsText)));
 					Outcome = Outcome.Failure;
 					return this;
 				}

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Between.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Between.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;
 using Mockolate;
+using Mockolate.Exceptions;
 using Mockolate.Verify;
 
 namespace aweXpect;
@@ -67,17 +69,36 @@ public static partial class ThatVerificationResult
 			{
 				_expectation = asyncVerificationResult.Expectation;
 				Actual = actual;
-				Outcome = await asyncVerificationResult.VerifyAsync(interactions =>
+				try
 				{
-					string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
-					expectationBuilder.UpdateContexts(contexts => contexts.Add(
-						new ResultContext.SyncCallback("Interactions", () => context)));
-					_count = interactions.Length;
-					return interactions.Length >= minimum && interactions.Length <= maximum;
-				})
-					? Outcome.Success
-					: Outcome.Failure;
-				return this;
+					Outcome = await asyncVerificationResult.VerifyAsync(interactions =>
+					{
+						string interactionsText = Formatter.Format(interactions, FormattingOptions.MultipleLines);
+						expectationBuilder.UpdateContexts(contexts => contexts
+							.Remove("Interactions")
+							.Add(new ResultContext.SyncCallback("Interactions", () => interactionsText)));
+						_count = interactions.Length;
+						return interactions.Length >= minimum && interactions.Length <= maximum;
+					})
+						? Outcome.Success
+						: Outcome.Failure;
+					return this;
+				}
+				catch (MockVerificationTimeoutException)
+				{
+					if (actual is IVerificationResult verificationResult)
+					{
+						string interactionsText = Formatter.Format(verificationResult.MockInteractions.Interactions,
+							FormattingOptions.MultipleLines);
+						expectationBuilder.UpdateContexts(contexts => contexts
+							.Remove("Interactions")
+							.Add(new ResultContext.SyncCallback("Interactions",
+								() => interactionsText)));
+					}
+
+					Outcome = Outcome.Failure;
+					return this;
+				}
 			}
 
 			IVerificationResult result = actual;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Between.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Between.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Times.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Times.cs
@@ -10,6 +10,7 @@ using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;
 using Mockolate;
+using Mockolate.Exceptions;
 using Mockolate.Verify;
 
 namespace aweXpect;
@@ -67,17 +68,36 @@ public static partial class ThatVerificationResult
 			{
 				_expectation = asyncVerificationResult.Expectation;
 				Actual = actual;
-				Outcome = await asyncVerificationResult.VerifyAsync(interactions =>
+				try
 				{
-					string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
-					expectationBuilder.UpdateContexts(contexts => contexts.Add(
-						new ResultContext.SyncCallback("Interactions", () => context)));
-					_count = interactions.Length;
-					return predicate(_count);
-				})
-					? Outcome.Success
-					: Outcome.Failure;
-				return this;
+					Outcome = await asyncVerificationResult.VerifyAsync(interactions =>
+					{
+						string interactionsText = Formatter.Format(interactions, FormattingOptions.MultipleLines);
+						expectationBuilder.UpdateContexts(contexts => contexts
+							.Remove("Interactions")
+							.Add(new ResultContext.SyncCallback("Interactions", () => interactionsText)));
+						_count = interactions.Length;
+						return predicate(_count);
+					})
+						? Outcome.Success
+						: Outcome.Failure;
+					return this;
+				}
+				catch (MockVerificationTimeoutException)
+				{
+					if (actual is IVerificationResult verificationResult)
+					{
+						string interactionsText = Formatter.Format(verificationResult.MockInteractions.Interactions,
+							FormattingOptions.MultipleLines);
+						expectationBuilder.UpdateContexts(contexts => contexts
+							.Remove("Interactions")
+							.Add(new ResultContext.SyncCallback("Interactions",
+								() => interactionsText)));
+					}
+
+					Outcome = Outcome.Failure;
+					return this;
+				}
 			}
 
 			IVerificationResult result = actual;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Times.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Times.cs
@@ -85,16 +85,12 @@ public static partial class ThatVerificationResult
 				}
 				catch (MockVerificationTimeoutException)
 				{
-					if (actual is IVerificationResult verificationResult)
-					{
-						string interactionsText = Formatter.Format(verificationResult.MockInteractions.Interactions,
-							FormattingOptions.MultipleLines);
-						expectationBuilder.UpdateContexts(contexts => contexts
-							.Remove("Interactions")
-							.Add(new ResultContext.SyncCallback("Interactions",
-								() => interactionsText)));
-					}
-
+					string interactionsText = Formatter.Format(((IVerificationResult)actual).MockInteractions.Interactions,
+						FormattingOptions.MultipleLines);
+					expectationBuilder.UpdateContexts(contexts => contexts
+						.Remove("Interactions")
+						.Add(new ResultContext.SyncCallback("Interactions",
+							() => interactionsText)));
 					Outcome = Outcome.Failure;
 					return this;
 				}

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.cs
@@ -77,16 +77,12 @@ public static partial class ThatVerificationResult
 				}
 				catch (MockVerificationTimeoutException)
 				{
-					if (actual is IVerificationResult verificationResult)
-					{
-						string interactionsText = Formatter.Format(verificationResult.MockInteractions.Interactions,
-							FormattingOptions.MultipleLines);
-						expectationBuilder.UpdateContexts(contexts => contexts
-							.Remove("Interactions")
-							.Add(new ResultContext.SyncCallback("Interactions",
-								() => interactionsText)));
-					}
-
+					string interactionsText = Formatter.Format(((IVerificationResult)actual).MockInteractions.Interactions,
+						FormattingOptions.MultipleLines);
+					expectationBuilder.UpdateContexts(contexts => contexts
+						.Remove("Interactions")
+						.Add(new ResultContext.SyncCallback("Interactions",
+							() => interactionsText)));
 					Outcome = Outcome.Failure;
 					return this;
 				}
@@ -276,15 +272,12 @@ public static partial class ThatVerificationResult
 				}
 				catch (MockVerificationTimeoutException)
 				{
-					if (actual is IVerificationResult verificationResult)
-					{
-						string interactionsText = Formatter.Format(verificationResult.MockInteractions.Interactions,
-							FormattingOptions.MultipleLines);
-						expectationBuilder.UpdateContexts(contexts => contexts
-							.Remove("Interactions")
-							.Add(new ResultContext.SyncCallback("Interactions",
-								() => interactionsText)));
-					}
+					string interactionsText = Formatter.Format(((IVerificationResult)actual).MockInteractions.Interactions,
+						FormattingOptions.MultipleLines);
+					expectationBuilder.UpdateContexts(contexts => contexts
+						.Remove("Interactions")
+						.Add(new ResultContext.SyncCallback("Interactions",
+							() => interactionsText)));
 					Outcome = Outcome.Failure;
 					return this;
 				}

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using Mockolate;
+using Mockolate.Exceptions;
 using Mockolate.Verify;
 
 namespace aweXpect;
@@ -58,17 +60,36 @@ public static partial class ThatVerificationResult
 			{
 				_expectation = asyncVerificationResult.Expectation;
 				Actual = actual;
-				Outcome = await asyncVerificationResult.VerifyAsync(interactions =>
+				try
 				{
-					string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
-					expectationBuilder.UpdateContexts(contexts => contexts.Add(
-						new ResultContext.SyncCallback("Interactions", () => context)));
-					_count = interactions.Length;
-					return interactions.Length == expected;
-				})
-					? Outcome.Success
-					: Outcome.Failure;
-				return this;
+					Outcome = await asyncVerificationResult.VerifyAsync(interactions =>
+					{
+						string interactionsText = Formatter.Format(interactions, FormattingOptions.MultipleLines);
+						expectationBuilder.UpdateContexts(contexts => contexts
+							.Remove("Interactions")
+							.Add(new ResultContext.SyncCallback("Interactions", () => interactionsText)));
+						_count = interactions.Length;
+						return interactions.Length == expected;
+					})
+						? Outcome.Success
+						: Outcome.Failure;
+					return this;
+				}
+				catch (MockVerificationTimeoutException)
+				{
+					if (actual is IVerificationResult verificationResult)
+					{
+						string interactionsText = Formatter.Format(verificationResult.MockInteractions.Interactions,
+							FormattingOptions.MultipleLines);
+						expectationBuilder.UpdateContexts(contexts => contexts
+							.Remove("Interactions")
+							.Add(new ResultContext.SyncCallback("Interactions",
+								() => interactionsText)));
+					}
+
+					Outcome = Outcome.Failure;
+					return this;
+				}
 			}
 
 			IVerificationResult result = actual;
@@ -238,17 +259,35 @@ public static partial class ThatVerificationResult
 			{
 				_expectation = asyncVerificationResult.Expectation;
 				Actual = actual;
-				Outcome = await asyncVerificationResult.VerifyAsync(interactions =>
+				try
 				{
-					string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
-					expectationBuilder.UpdateContexts(contexts => contexts.Add(
-						new ResultContext.SyncCallback("Interactions", () => context)));
-					_count = interactions.Length;
-					return interactions.Length >= expected;
-				})
-					? Outcome.Success
-					: Outcome.Failure;
-				return this;
+					Outcome = await asyncVerificationResult.VerifyAsync(interactions =>
+					{
+						string interactionsText = Formatter.Format(interactions, FormattingOptions.MultipleLines);
+						expectationBuilder.UpdateContexts(contexts => contexts
+							.Remove("Interactions")
+							.Add(new ResultContext.SyncCallback("Interactions", () => interactionsText)));
+						_count = interactions.Length;
+						return interactions.Length >= expected;
+					})
+						? Outcome.Success
+						: Outcome.Failure;
+					return this;
+				}
+				catch (MockVerificationTimeoutException)
+				{
+					if (actual is IVerificationResult verificationResult)
+					{
+						string interactionsText = Formatter.Format(verificationResult.MockInteractions.Interactions,
+							FormattingOptions.MultipleLines);
+						expectationBuilder.UpdateContexts(contexts => contexts
+							.Remove("Interactions")
+							.Add(new ResultContext.SyncCallback("Interactions",
+								() => interactionsText)));
+					}
+					Outcome = Outcome.Failure;
+					return this;
+				}
 			}
 
 			IVerificationResult result = actual;
@@ -257,8 +296,8 @@ public static partial class ThatVerificationResult
 			Outcome = result.Verify(interactions =>
 			{
 				string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
-				expectationBuilder.UpdateContexts(contexts => contexts.Add(
-					new ResultContext.SyncCallback("Interactions", () => context)));
+				expectationBuilder.UpdateContexts(contexts => contexts
+					.Add(new ResultContext.SyncCallback("Interactions", () => context)));
 				_count = interactions.Length;
 				return interactions.Length >= expected;
 			})

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastOnceTests.cs
@@ -182,5 +182,32 @@ public sealed partial class ThatVerificationResultIs
 
 			await That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task WhenNotInvoked_Within_ShouldFailWithDescriptiveMessage()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			sut.MyMethod(1, true);
+			sut.MyMethod(2, true);
+
+			async Task Act()
+			{
+				await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false))).AtLeastOnce().Within(50.Milliseconds());
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+				             invoked method MyMethod(1, false) at least once,
+				             but never found it
+
+				             Interactions:
+				             [
+				               [0] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(1, True),
+				               [1] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(2, True)
+				             ]
+				             """);
+		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTests.cs
@@ -208,5 +208,34 @@ public sealed partial class ThatVerificationResultIs
 				              []
 				              """);
 		}
+
+		[Fact]
+		public async Task WhenNotInvoked_Within_ShouldFailWithDescriptiveMessage()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			sut.MyMethod(1, true);
+			sut.MyMethod(2, true);
+			sut.MyMethod(3, true);
+
+			async Task Act()
+			{
+				await That(sut.Mock.Verify.MyMethod(It.IsAny<int>(), It.Is(true))).AtLeast(4).Within(50.Milliseconds());
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+				             invoked method MyMethod(It.IsAny<int>(), true) at least 4 times,
+				             but found it only 3 times
+
+				             Interactions:
+				             [
+				               [0] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(1, True),
+				               [1] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(2, True),
+				               [2] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(3, True)
+				             ]
+				             """);
+		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTwiceTests.cs
@@ -192,5 +192,34 @@ public sealed partial class ThatVerificationResultIs
 
 			await That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task WhenNotInvoked_Within_ShouldFailWithDescriptiveMessage()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			sut.MyMethod(1, true);
+			sut.MyMethod(2, true);
+			sut.MyMethod(3, true);
+
+			async Task Act()
+			{
+				await That(sut.Mock.Verify.MyMethod(It.Is(2), It.Is(true))).AtLeastTwice().Within(50.Milliseconds());
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+				             invoked method MyMethod(2, true) at least twice,
+				             but found it only once
+
+				             Interactions:
+				             [
+				               [0] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(1, True),
+				               [1] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(2, True),
+				               [2] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(3, True)
+				             ]
+				             """);
+		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.BetweenTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.BetweenTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using aweXpect.Chronology;
+using aweXpect.Core;
 using Mockolate;
 using Xunit.Sdk;
 
@@ -225,6 +226,35 @@ public sealed partial class ThatVerificationResultIs
 				              *
 				              ]
 				              """).AsWildcard();
+		}
+
+		[Fact]
+		public async Task WhenNotInvoked_Within_ShouldFailWithDescriptiveMessage()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			sut.MyMethod(1, true);
+			sut.MyMethod(2, true);
+			sut.MyMethod(3, true);
+
+			async Task Act()
+			{
+				await That(sut.Mock.Verify.MyMethod(It.IsAny<int>(), It.Is(true))).Between(4).And(6.Times()).Within(50.Milliseconds());
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+				             invoked method MyMethod(It.IsAny<int>(), true) between 4 and 6 times,
+				             but found it only 3 times
+
+				             Interactions:
+				             [
+				               [0] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(1, True),
+				               [1] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(2, True),
+				               [2] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(3, True)
+				             ]
+				             """);
 		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ExactlyTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ExactlyTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using aweXpect.Chronology;
+using aweXpect.Core;
 using Mockolate;
 using Xunit.Sdk;
 
@@ -217,6 +218,37 @@ public sealed partial class ThatVerificationResultIs
 				              Interactions:
 				              []
 				              """);
+		}
+
+		[Fact]
+		public async Task WhenNotInvoked_Within_ShouldFailWithDescriptiveMessage()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			sut.MyMethod(1, true);
+			sut.MyMethod(2, true);
+			sut.MyMethod(3, true);
+			sut.MyMethod(4, true);
+
+			async Task Act()
+			{
+				await That(sut.Mock.Verify.MyMethod(It.IsAny<int>(), It.Is(true))).Exactly(3.Times()).Within(50.Milliseconds());
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+				             invoked method MyMethod(It.IsAny<int>(), true) exactly 3 times,
+				             but found it 4 times
+
+				             Interactions:
+				             [
+				               [0] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(1, True),
+				               [1] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(2, True),
+				               [2] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(3, True),
+				               [3] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(4, True)
+				             ]
+				             """);
 		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.OnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.OnceTests.cs
@@ -202,5 +202,26 @@ public sealed partial class ThatVerificationResultIs
 				             ]
 				             """);
 		}
+
+		[Fact]
+		public async Task WhenNotInvoked_Within_ShouldFailWithDescriptiveMessage()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			async Task Act()
+			{
+				await That(sut.Mock.Verify.MyMethod(It.IsAny<int>(), It.Is(true))).Once().Within(50.Milliseconds());
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+				             invoked method MyMethod(It.IsAny<int>(), true) exactly once,
+				             but never found it
+
+				             Interactions:
+				             []
+				             """);
+		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
@@ -199,5 +199,36 @@ public sealed partial class ThatVerificationResultIs
 
 			await backgroundTask;
 		}
+
+		[Fact]
+		public async Task WhenNotInvoked_Within_ShouldFailWithDescriptiveMessage()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			sut.MyMethod(1, true);
+			sut.MyMethod(2, true);
+			sut.MyMethod(3, true);
+			sut.MyMethod(4, true);
+
+			async Task Act()
+			{
+				await That(sut.Mock.Verify.MyMethod(It.IsAny<int>(), It.Is(true))).Times(x => x != 4).Within(50.Milliseconds());
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+				             invoked method MyMethod(It.IsAny<int>(), true) according to the predicate x => x != 4,
+				             but found it 4 times
+
+				             Interactions:
+				             [
+				               [0] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(1, True),
+				               [1] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(2, True),
+				               [2] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(3, True),
+				               [3] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(4, True)
+				             ]
+				             """);
+		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TwiceTests.cs
@@ -201,5 +201,36 @@ public sealed partial class ThatVerificationResultIs
 
 			await That(Act).DoesNotThrow();
 		}
+
+		[Fact]
+		public async Task WhenNotInvoked_Within_ShouldFailWithDescriptiveMessage()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			sut.MyMethod(1, true);
+			sut.MyMethod(2, true);
+			sut.MyMethod(3, true);
+			sut.MyMethod(4, true);
+
+			async Task Act()
+			{
+				await That(sut.Mock.Verify.MyMethod(It.Is(3), It.Is(true))).Twice().Within(50.Milliseconds());
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage("""
+				             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+				             invoked method MyMethod(3, true) exactly twice,
+				             but found it only once
+
+				             Interactions:
+				             [
+				               [0] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(1, True),
+				               [1] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(2, True),
+				               [2] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(3, True),
+				               [3] invoke method global::aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService.MyMethod(4, True)
+				             ]
+				             """);
+		}
 	}
 }


### PR DESCRIPTION
This PR improves the failure output when Mockolate verifications are used with `Within(...)` by ensuring timeouts produce aweXpect failure messages that include a useful “Interactions” context, and adds regression tests for the expected messages.

### Key Changes:
- Catch `MockVerificationTimeoutException` during async verification to convert timeouts into aweXpect constraint failures and attach interactions context.
- Add new test cases asserting descriptive failure messages for `Within(...)` across multiple count-based constraints.
- Update Mockolate package reference from `2.0.0-pre.7` to `2.0.0`.

---

- *Fixes the last issue from #78*