### PR TITLE
chore: bump Mockolate to v2.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 		<PackageVersion Include="aweXpect" Version="2.31.0" />
 		<PackageVersion Include="aweXpect.Core" Version="2.28.0" />
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
-		<PackageVersion Include="Mockolate" Version="2.2.0-pre.2" />
+		<PackageVersion Include="Mockolate" Version="2.2.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1" />


### PR DESCRIPTION
Updates the centrally-managed NuGet dependency version for Mockolate from a pre-release to the stable 2.2.0 release, aligning the repository’s dependency set with a finalized upstream package.

**Changes:**
- Bump `Mockolate` package version from `2.2.0-pre.2` to `2.2.0` in central package version management.