### PR TITLE
coverage: add missing tests

### DIFF
--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastOnceTests.cs
@@ -209,5 +209,76 @@ public sealed partial class ThatVerificationResultIs
 				             ]
 				             """);
 		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenInvokedNever_ShouldSucceed()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.AtLeastOnce());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInvokedOnce_ShouldFail()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				sut.MyMethod(1, false);
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.AtLeastOnce());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+					             invoked method MyMethod(1, false) less than once,
+					             but found it once
+
+					             Interactions:
+					             [
+					               [0] invoke method MyMethod(1, False)
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenInvokedTwice_ShouldFail()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				sut.MyMethod(1, false);
+				sut.MyMethod(1, false);
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.AtLeastOnce());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+					             invoked method MyMethod(1, false) less than once,
+					             but found it twice
+
+					             Interactions:
+					             [
+					               [0] invoke method MyMethod(1, False),
+					               [1] invoke method MyMethod(1, False)
+					             ]
+					             """);
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTests.cs
@@ -237,5 +237,74 @@ public sealed partial class ThatVerificationResultIs
 				             ]
 				             """);
 		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData(3, 4)]
+			[InlineData(6, 8)]
+			public async Task WhenInvokedAtLeastExpectedTimes_ShouldFail(int times, int invocationTimes)
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				for (int i = 0; i < invocationTimes; i++)
+				{
+					sut.MyMethod(1, false);
+				}
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.AtLeast(times));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+					              invoked method MyMethod(1, false) less than {times} times,
+					              but found it {invocationTimes} times
+
+					              Interactions:
+					              [
+					              *
+					              ]
+					              """).AsWildcard();
+			}
+
+			[Theory]
+			[InlineData(4, 3)]
+			[InlineData(8, 6)]
+			public async Task WhenInvokedFewerTimes_ShouldSucceed(int times, int invocationTimes)
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				for (int i = 0; i < invocationTimes; i++)
+				{
+					sut.MyMethod(1, false);
+				}
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.AtLeast(times));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNeverInvoked_ShouldSucceed()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.AtLeast(3));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTests.cs
@@ -1,4 +1,4 @@
-﻿using Mockolate;
+using Mockolate;
 using Xunit.Sdk;
 
 namespace aweXpect.Mockolate.Tests;
@@ -7,6 +7,36 @@ public sealed partial class ThatVerificationResultIs
 {
 	public sealed class AtMost
 	{
+		[Theory]
+		[InlineData(1, "once")]
+		[InlineData(2, "twice")]
+		public async Task WhenExpectedNeverButInvoked_ShouldFail(int invocationTimes, string amountString)
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			for (int i = 0; i < invocationTimes; i++)
+			{
+				sut.MyMethod(1, false);
+			}
+
+			async Task Act()
+			{
+				await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false))).AtMost(0);
+			}
+
+			await That(Act).Throws<XunitException>()
+				.WithMessage($"""
+				              Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+				              invoked method MyMethod(1, false) at most never,
+				              but found it {amountString}
+
+				              Interactions:
+				              [
+				              *
+				              ]
+				              """).AsWildcard();
+		}
+
 		[Theory]
 		[InlineData(3)]
 		[InlineData(6)]
@@ -77,6 +107,83 @@ public sealed partial class ThatVerificationResultIs
 				              *
 				              ]
 				              """).AsWildcard();
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData(4, 3)]
+			[InlineData(6, 4)]
+			public async Task WhenInvokedAtMostExpected_ShouldFail(int times, int invocationTimes)
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				for (int i = 0; i < invocationTimes; i++)
+				{
+					sut.MyMethod(1, false);
+				}
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.AtMost(times));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+					              invoked method MyMethod(1, false) more than {times} times,
+					              but found it only {invocationTimes} times
+
+					              Interactions:
+					              [
+					              *
+					              ]
+					              """).AsWildcard();
+			}
+
+			[Theory]
+			[InlineData(3, 4)]
+			[InlineData(6, 8)]
+			public async Task WhenInvokedMoreThanExpected_ShouldSucceed(int times, int invocationTimes)
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				for (int i = 0; i < invocationTimes; i++)
+				{
+					sut.MyMethod(1, false);
+				}
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.AtMost(times));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNeverInvoked_ShouldFail()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.AtMost(3));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+					             invoked method MyMethod(1, false) more than 3 times,
+					             but never found it
+
+					             Interactions:
+					             []
+					             """);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.BetweenTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.BetweenTests.cs
@@ -239,7 +239,8 @@ public sealed partial class ThatVerificationResultIs
 
 			async Task Act()
 			{
-				await That(sut.Mock.Verify.MyMethod(It.IsAny<int>(), It.Is(true))).Between(4).And(6.Times()).Within(50.Milliseconds());
+				await That(sut.Mock.Verify.MyMethod(It.IsAny<int>(), It.Is(true))).Between(4).And(6.Times())
+					.Within(50.Milliseconds());
 			}
 
 			await That(Act).Throws<XunitException>()
@@ -255,6 +256,83 @@ public sealed partial class ThatVerificationResultIs
 				               [2] invoke method MyMethod(3, True)
 				             ]
 				             """);
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData(3, 5, 3)]
+			[InlineData(3, 5, 4)]
+			[InlineData(3, 5, 5)]
+			public async Task WhenInvokedInRange_ShouldFail(int minimum, int maximum, int invocationTimes)
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				for (int i = 0; i < invocationTimes; i++)
+				{
+					sut.MyMethod(1, false);
+				}
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.Between(minimum).And(maximum));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+					              invoked method MyMethod(1, false) not between {minimum} and {maximum} times,
+					              but found it {invocationTimes} times
+
+					              Interactions:
+					              [
+					              *
+					              ]
+					              """).AsWildcard();
+			}
+
+			[Theory]
+			[InlineData(3, 5, 2)]
+			[InlineData(8, 12, 6)]
+			public async Task WhenInvokedTooFewTimes_ShouldSucceed(int minimum, int maximum, int invocationTimes)
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				for (int i = 0; i < invocationTimes; i++)
+				{
+					sut.MyMethod(1, false);
+				}
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.Between(minimum).And(maximum));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(3, 5, 6)]
+			[InlineData(8, 12, 14)]
+			public async Task WhenInvokedTooOften_ShouldSucceed(int minimum, int maximum, int invocationTimes)
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				for (int i = 0; i < invocationTimes; i++)
+				{
+					sut.MyMethod(1, false);
+				}
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.Between(minimum).And(maximum));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ExactlyTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ExactlyTests.cs
@@ -232,7 +232,8 @@ public sealed partial class ThatVerificationResultIs
 
 			async Task Act()
 			{
-				await That(sut.Mock.Verify.MyMethod(It.IsAny<int>(), It.Is(true))).Exactly(3.Times()).Within(50.Milliseconds());
+				await That(sut.Mock.Verify.MyMethod(It.IsAny<int>(), It.Is(true))).Exactly(3.Times())
+					.Within(50.Milliseconds());
 			}
 
 			await That(Act).Throws<XunitException>()
@@ -249,6 +250,96 @@ public sealed partial class ThatVerificationResultIs
 				               [3] invoke method MyMethod(4, True)
 				             ]
 				             """);
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData(3)]
+			[InlineData(6)]
+			public async Task WhenInvokedExactlyTheSameTimes_ShouldFail(int times)
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				for (int i = 0; i < times; i++)
+				{
+					sut.MyMethod(1, false);
+				}
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.Exactly(times));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+					              invoked method MyMethod(1, false) not exactly {times} times,
+					              but it was
+
+					              Interactions:
+					              [
+					              *
+					              ]
+					              """).AsWildcard();
+			}
+
+			[Theory]
+			[InlineData(4, 3)]
+			[InlineData(8, 6)]
+			public async Task WhenInvokedFewerTimes_ShouldSucceed(int times, int invocationTimes)
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				for (int i = 0; i < invocationTimes; i++)
+				{
+					sut.MyMethod(1, false);
+				}
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.Exactly(times));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(3, 4)]
+			[InlineData(6, 8)]
+			public async Task WhenInvokedMoreTimes_ShouldSucceed(int times, int invocationTimes)
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				for (int i = 0; i < invocationTimes; i++)
+				{
+					sut.MyMethod(1, false);
+				}
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.Exactly(times));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNeverInvoked_ShouldSucceed()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.Exactly(3));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Adds missing coverage for negated verification-result expectations in the Mockolate integration tests, plus a couple of small formatting-only tweaks to keep long fluent chains readable.

**Changes:**
- Add `NegatedTests` coverage for `Exactly`, `Between`, `AtLeast`, `AtLeastOnce`, and `AtMost` verification-result constraints.
- Add explicit `AtMost(0)` (“never”) failure-message coverage (including singular/plural wording via `once`/`twice`).