### PR TITLE
refactor: specify encoding in editorconfig and cleanup code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 [*]
 
 #### Core EditorConfig Options ####
+charset = utf-8
 
 # Indentation and spacing
 indent_size = 4
@@ -14,6 +15,7 @@ tab_width = 4
 # New line preferences
 end_of_line = crlf
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 # C# files
 [*.cs]

--- a/Benchmarks/aweXpect.Mockolate.Benchmarks/HappyCaseBenchmarks.Dummy.cs
+++ b/Benchmarks/aweXpect.Mockolate.Benchmarks/HappyCaseBenchmarks.Dummy.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 
 namespace aweXpect.Mockolate.Benchmarks;
 

--- a/Benchmarks/aweXpect.Mockolate.Benchmarks/HappyCaseBenchmarks.cs
+++ b/Benchmarks/aweXpect.Mockolate.Benchmarks/HappyCaseBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;

--- a/Benchmarks/aweXpect.Mockolate.Benchmarks/Program.cs
+++ b/Benchmarks/aweXpect.Mockolate.Benchmarks/Program.cs
@@ -1,3 +1,3 @@
-﻿using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Running;
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,13 +3,13 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.31.0" />
-		<PackageVersion Include="aweXpect.Core" Version="2.28.0" />
-		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0" />
-		<PackageVersion Include="Mockolate" Version="2.2.0" />
+		<PackageVersion Include="aweXpect" Version="2.31.0"/>
+		<PackageVersion Include="aweXpect.Core" Version="2.28.0"/>
+		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0"/>
+		<PackageVersion Include="Mockolate" Version="2.2.0"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Nullable" Version="1.3.1" />
+		<PackageVersion Include="Nullable" Version="1.3.1"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nuke.Common" Version="10.1.0"/>
@@ -18,15 +18,15 @@
 		<PackageVersion Include="SharpCompress" Version="0.47.3"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Meziantou.Analyzer" Version="2.0.163" />
+		<PackageVersion Include="Meziantou.Analyzer" Version="2.0.163"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-		<PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
+		<PackageVersion Include="BenchmarkDotNet" Version="0.15.8"/>
 		<PackageVersion Include="xunit" Version="2.9.3"/>
 		<PackageVersion Include="xunit.v3" Version="3.2.2"/>
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
-		<PackageVersion Include="coverlet.collector" Version="8.0.1" />
-		<PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
+		<PackageVersion Include="coverlet.collector" Version="8.0.1"/>
+		<PackageVersion Include="PublicApiGenerator" Version="11.5.4"/>
 	</ItemGroup>
 </Project>

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -22,7 +22,7 @@ namespace Build;
 
 partial class Build
 {
-	private static bool DisableMutationTests = true;
+	private static readonly bool DisableMutationTests = true;
 	static string MutationCommentBody = "";
 
 	Target MutationTests => _ => _
@@ -60,6 +60,7 @@ partial class Build
 					branchName = "release/" + version;
 					Log.Information("Use release branch analysis for '{BranchName}'", branchName);
 				}
+
 				File.WriteAllText(ArtifactsDirectory / "BranchName.txt", branchName);
 
 				string configText = $$"""
@@ -129,7 +130,8 @@ partial class Build
 			File.WriteAllText(ArtifactsDirectory / "PR_Comment.md", body);
 
 			if (prId != null)
-			{				File.WriteAllText(ArtifactsDirectory / "PR.txt", prId.Value.ToString());
+			{
+				File.WriteAllText(ArtifactsDirectory / "PR.txt", prId.Value.ToString());
 			}
 		});
 
@@ -191,7 +193,8 @@ partial class Build
 					else
 					{
 						Log.Information($"Update comment:\n{body}");
-						await gitHubClient.Issue.Comment.Update("aweXpect", "aweXpect.Mockolate", commentId.Value, body);
+						await gitHubClient.Issue.Comment.Update("aweXpect", "aweXpect.Mockolate", commentId.Value,
+							body);
 					}
 				}
 			}

--- a/Pipeline/Build.Pack.cs
+++ b/Pipeline/Build.Pack.cs
@@ -32,7 +32,8 @@ partial class Build
 				$"[![Changelog](https://img.shields.io/badge/Changelog-v{version}-blue)](https://github.com/aweXpect/aweXpect.Mockolate/releases/tag/v{version})");
 			foreach (string line in lines.Skip(1))
 			{
-				if (line.StartsWith("[![Build](https://github.com/aweXpect/aweXpect.Mockolate/actions/workflows/build.yml") ||
+				if (line.StartsWith(
+					    "[![Build](https://github.com/aweXpect/aweXpect.Mockolate/actions/workflows/build.yml") ||
 				    line.StartsWith("[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure"))
 				{
 					continue;

--- a/Source/aweXpect.Mockolate/Helpers/MyDescribableSubject.cs
+++ b/Source/aweXpect.Mockolate/Helpers/MyDescribableSubject.cs
@@ -1,4 +1,4 @@
-﻿using aweXpect.Core;
+using aweXpect.Core;
 using Mockolate;
 
 namespace aweXpect.Helpers;

--- a/Source/aweXpect.Mockolate/Helpers/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/Source/aweXpect.Mockolate/Helpers/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if !NET8_0_OR_GREATER
+#if !NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 
 // Licensed to the .NET Foundation under one or more agreements.

--- a/Source/aweXpect.Mockolate/Helpers/ThatExtensions.cs
+++ b/Source/aweXpect.Mockolate/Helpers/ThatExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using aweXpect.Core;
 

--- a/Source/aweXpect.Mockolate/Options/WithinOptions.cs
+++ b/Source/aweXpect.Mockolate/Options/WithinOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 
 namespace aweXpect.Options;

--- a/Source/aweXpect.Mockolate/Results/AndOrWithinResult.cs
+++ b/Source/aweXpect.Mockolate/Results/AndOrWithinResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect.Mockolate/ThatMockVerify.AllInteractionsAreVerified.cs
+++ b/Source/aweXpect.Mockolate/ThatMockVerify.AllInteractionsAreVerified.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;

--- a/Source/aweXpect.Mockolate/ThatMockVerify.AllSetupsAreUsed.cs
+++ b/Source/aweXpect.Mockolate/ThatMockVerify.AllSetupsAreUsed.cs
@@ -32,7 +32,8 @@ public static partial class ThatMockVerify
 		public ConstraintResult IsMetBy(IMockVerify<TVerify> actual)
 		{
 			Actual = actual;
-			Outcome = actual is IMock mock && mock.MockRegistry.GetUnusedSetups(mock.MockRegistry.Interactions).Count == 0
+			Outcome = actual is IMock mock &&
+			          mock.MockRegistry.GetUnusedSetups(mock.MockRegistry.Interactions).Count == 0
 				? Outcome.Success
 				: Outcome.Failure;
 			return this;

--- a/Source/aweXpect.Mockolate/ThatMockVerify.cs
+++ b/Source/aweXpect.Mockolate/ThatMockVerify.cs
@@ -1,4 +1,4 @@
-﻿using Mockolate.Verify;
+using Mockolate.Verify;
 
 namespace aweXpect;
 

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.AtLeast.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.AtLeast.cs
@@ -1,4 +1,4 @@
-﻿using aweXpect.Core;
+using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.AtLeastOnce.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.AtLeastOnce.cs
@@ -1,4 +1,4 @@
-﻿using aweXpect.Core;
+using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.AtLeastTwice.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.AtLeastTwice.cs
@@ -1,4 +1,4 @@
-﻿using aweXpect.Core;
+using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.AtMost.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.AtMost.cs
@@ -1,4 +1,4 @@
-﻿using aweXpect.Core;
+using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Results;
 using Mockolate.Verify;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.AtMostOnce.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.AtMostOnce.cs
@@ -1,4 +1,4 @@
-﻿using aweXpect.Core;
+using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Results;
 using Mockolate.Verify;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.AtMostTwice.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.AtMostTwice.cs
@@ -1,4 +1,4 @@
-﻿using aweXpect.Core;
+using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Results;
 using Mockolate.Verify;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Between.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Between.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Exactly.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Exactly.cs
@@ -1,4 +1,4 @@
-﻿using aweXpect.Core;
+using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Never.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Never.cs
@@ -1,4 +1,4 @@
-﻿using aweXpect.Core;
+using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Once.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Once.cs
@@ -1,4 +1,4 @@
-﻿using aweXpect.Core;
+using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
@@ -8,8 +8,8 @@ using aweXpect.Core.Constraints;
 using aweXpect.Helpers;
 using aweXpect.Results;
 using Mockolate;
-using Mockolate.Verify;
 using Mockolate.Interactions;
+using Mockolate.Verify;
 
 namespace aweXpect;
 
@@ -51,6 +51,7 @@ public static partial class ThatVerificationResult
 				{
 					result = false;
 				}
+
 				verificationResult = check(verify);
 			}
 
@@ -59,11 +60,14 @@ public static partial class ThatVerificationResult
 			Outcome = result ? Outcome.Success : Outcome.Failure;
 			if (!result)
 			{
-				string context = Formatter.Format(((IVerificationResult)actual).MockInteractions, FormattingOptions.MultipleLines);
+				string context = Formatter.Format(((IVerificationResult)actual).MockInteractions,
+					FormattingOptions.MultipleLines);
 				expectationBuilder.UpdateContexts(contexts => contexts.Add(
 					new ResultContext.SyncCallback("Interactions", () => context)));
 			}
+
 			return this;
+
 			bool VerifyInteractions(IInteraction[] filteredInteractions, IVerificationResult currentVerificationResult)
 			{
 				bool hasInteractionAfter = filteredInteractions.Any(x => x.Index > after);
@@ -72,26 +76,27 @@ public static partial class ThatVerificationResult
 					: int.MaxValue;
 				if (!hasInteractionAfter && _error is null)
 				{
-					_error = filteredInteractions.Length > 0 ? $"{currentVerificationResult.Expectation} too early" : $"{currentVerificationResult.Expectation} not at all";
+					_error = filteredInteractions.Length > 0
+						? $"{currentVerificationResult.Expectation} too early"
+						: $"{currentVerificationResult.Expectation} not at all";
 				}
+
 				return hasInteractionAfter;
 			}
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
-			var separator = $", then{Environment.NewLine}{indentation}";
+			string separator = $", then{Environment.NewLine}{indentation}";
 			stringBuilder.Append(string.Join(separator, _expectations)).Append(" in order");
 		}
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append(it).Append(' ').Append(_error);
-		}
+			=> stringBuilder.Append(it).Append(' ').Append(_error);
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
-			var separator = $", then{Environment.NewLine}{indentation}";
+			string separator = $", then{Environment.NewLine}{indentation}";
 			stringBuilder.Append(string.Join(separator, _expectations)).Append(" not in order");
 		}
 
@@ -102,7 +107,7 @@ public static partial class ThatVerificationResult
 		{
 			if (typeof(TValue) == typeof(IDescribableSubject) &&
 			    Actual is IVerificationResult<T> verificationResult &&
-				new MyDescribableSubject<T>(verificationResult.Object as IMock) is TValue describableSubject)
+			    new MyDescribableSubject<T>(verificationResult.Object as IMock) is TValue describableSubject)
 			{
 				value = describableSubject;
 				return true;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Times.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Times.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Twice.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Twice.cs
@@ -1,4 +1,4 @@
-﻿using aweXpect.Core;
+using aweXpect.Core;
 using aweXpect.Helpers;
 using aweXpect.Options;
 using aweXpect.Results;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/aweXpect.Mockolate/Usings.cs
+++ b/Source/aweXpect.Mockolate/Usings.cs
@@ -1,2 +1,2 @@
-﻿global using aweXpect.Formatting;
+global using aweXpect.Formatting;
 global using static aweXpect.Formatting.Format;

--- a/Source/aweXpect.Mockolate/Web/ItExtensions.HttpContent.IsJsonContent.cs
+++ b/Source/aweXpect.Mockolate/Web/ItExtensions.HttpContent.IsJsonContent.cs
@@ -91,10 +91,12 @@ public static class AweXpectItExtensions
 			params IEnumerable<(string Name, HttpHeaderValue Value)> headers)
 			=> _parameter.WithHeaders(headers);
 
-		public ItExtensions.IHttpContentParameter WithString(Func<string, bool> predicate, [CallerArgumentExpression(nameof(predicate))] string doNotPopulateThisValue = "")
+		public ItExtensions.IHttpContentParameter WithString(Func<string, bool> predicate,
+			[CallerArgumentExpression(nameof(predicate))] string doNotPopulateThisValue = "")
 			=> _parameter.WithString(predicate, doNotPopulateThisValue);
 
-		public ItExtensions.IHttpContentParameter WithBytes(Func<byte[], bool> predicate, [CallerArgumentExpression(nameof(predicate))] string doNotPopulateThisValue = "")
+		public ItExtensions.IHttpContentParameter WithBytes(Func<byte[], bool> predicate,
+			[CallerArgumentExpression(nameof(predicate))] string doNotPopulateThisValue = "")
 			=> _parameter.WithBytes(predicate, doNotPopulateThisValue);
 
 		public ItExtensions.IHttpContentParameter WithMediaType(string? mediaType)

--- a/Tests/aweXpect.Mockolate.Api.Tests/ApiAcceptance.cs
+++ b/Tests/aweXpect.Mockolate.Api.Tests/ApiAcceptance.cs
@@ -1,4 +1,4 @@
-﻿namespace aweXpect.Mockolate.Api.Tests;
+namespace aweXpect.Mockolate.Api.Tests;
 
 public sealed class ApiAcceptance
 {

--- a/Tests/aweXpect.Mockolate.Api.Tests/ApiApprovalTests.cs
+++ b/Tests/aweXpect.Mockolate.Api.Tests/ApiApprovalTests.cs
@@ -1,4 +1,4 @@
-﻿namespace aweXpect.Mockolate.Api.Tests;
+namespace aweXpect.Mockolate.Api.Tests;
 
 /// <summary>
 ///     Whenever a test fails, this means that the public API surface changed.

--- a/Tests/aweXpect.Mockolate.Api.Tests/Helper.cs
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Helper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/Tests/aweXpect.Mockolate.Api.Tests/Usings.cs
+++ b/Tests/aweXpect.Mockolate.Api.Tests/Usings.cs
@@ -1,5 +1,5 @@
-﻿global using System;
+global using System;
 global using System.Threading.Tasks;
-global using Xunit;
 global using aweXpect;
+global using Xunit;
 global using static aweXpect.Expect;

--- a/Tests/aweXpect.Mockolate.Api.Tests/aweXpect.Mockolate.Api.Tests.csproj
+++ b/Tests/aweXpect.Mockolate.Api.Tests/aweXpect.Mockolate.Api.Tests.csproj
@@ -5,13 +5,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\Source\aweXpect.Mockolate\aweXpect.Mockolate.csproj" />
+		<ProjectReference Include="..\..\Source\aweXpect.Mockolate\aweXpect.Mockolate.csproj"/>
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Remove="xunit" />
-		<PackageReference Include="xunit.v3" />
-		<PackageReference Include="PublicApiGenerator" />
+		<PackageReference Remove="xunit"/>
+		<PackageReference Include="xunit.v3"/>
+		<PackageReference Include="PublicApiGenerator"/>
 	</ItemGroup>
-	
+
 </Project>

--- a/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllInteractionsAreVerifiedTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllInteractionsAreVerifiedTests.cs
@@ -1,4 +1,4 @@
-﻿using Mockolate;
+using Mockolate;
 using Mockolate.Verify;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllSetupsAreUsedTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.AllSetupsAreUsedTests.cs
@@ -1,4 +1,4 @@
-﻿using Mockolate;
+using Mockolate;
 using Xunit.Sdk;
 
 namespace aweXpect.Mockolate.Tests;

--- a/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatMockVerifyIs.cs
@@ -1,4 +1,4 @@
-﻿namespace aweXpect.Mockolate.Tests;
+namespace aweXpect.Mockolate.Tests;
 
 public sealed partial class ThatMockVerifyIs
 {

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastOnceTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using aweXpect.Chronology;
 using Mockolate;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using aweXpect.Chronology;
 using Mockolate;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTwiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using aweXpect.Chronology;
 using Mockolate;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostOnceTests.cs
@@ -1,4 +1,4 @@
-﻿using Mockolate;
+using Mockolate;
 using Xunit.Sdk;
 
 namespace aweXpect.Mockolate.Tests;

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTwiceTests.cs
@@ -1,4 +1,4 @@
-﻿using Mockolate;
+using Mockolate;
 using Xunit.Sdk;
 
 namespace aweXpect.Mockolate.Tests;

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.BetweenTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.BetweenTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using aweXpect.Chronology;
 using aweXpect.Core;
 using Mockolate;

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ExactlyTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ExactlyTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using aweXpect.Chronology;
 using aweXpect.Core;
 using Mockolate;

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.NeverTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.NeverTests.cs
@@ -1,4 +1,4 @@
-﻿using Mockolate;
+using Mockolate;
 using Xunit.Sdk;
 
 namespace aweXpect.Mockolate.Tests;

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.OnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.OnceTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using aweXpect.Chronology;
 using Mockolate;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
@@ -1,4 +1,4 @@
-﻿using Mockolate;
+using Mockolate;
 using Xunit.Sdk;
 
 namespace aweXpect.Mockolate.Tests;

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
@@ -212,7 +212,8 @@ public sealed partial class ThatVerificationResultIs
 
 			async Task Act()
 			{
-				await That(sut.Mock.Verify.MyMethod(It.IsAny<int>(), It.Is(true))).Times(x => x != 4).Within(50.Milliseconds());
+				await That(sut.Mock.Verify.MyMethod(It.IsAny<int>(), It.Is(true))).Times(x => x != 4)
+					.Within(50.Milliseconds());
 			}
 
 			await That(Act).Throws<XunitException>()

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TwiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using aweXpect.Chronology;
 using Mockolate;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.cs
@@ -1,4 +1,4 @@
-﻿namespace aweXpect.Mockolate.Tests;
+namespace aweXpect.Mockolate.Tests;
 
 public sealed partial class ThatVerificationResultIs
 {

--- a/Tests/aweXpect.Mockolate.Tests/Usings.cs
+++ b/Tests/aweXpect.Mockolate.Tests/Usings.cs
@@ -1,5 +1,5 @@
-﻿global using System;
+global using System;
 global using System.Threading.Tasks;
-global using Xunit;
 global using aweXpect;
+global using Xunit;
 global using static aweXpect.Expect;

--- a/Tests/aweXpect.Mockolate.Tests/Web/ItExtensionsTests.HttpContentTests.IsJsonContentTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/Web/ItExtensionsTests.HttpContentTests.IsJsonContentTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
@@ -543,9 +543,9 @@ public sealed partial class ItExtensionsTests
 					HttpClient httpClient = HttpClient.CreateMock();
 					httpClient.Mock.Setup
 						.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithJsonMatching(new
-							{
-								foo = 1,
-							},
+						{
+							foo = 1,
+						},
 							new JsonDocumentOptions
 							{
 								AllowTrailingCommas = allowTrailingCommas,

--- a/Tests/aweXpect.Mockolate.Tests/Web/ItExtensionsTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/Web/ItExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER
 namespace aweXpect.Mockolate.Tests.Web;
 
 public sealed partial class ItExtensionsTests;

--- a/aweXpect.Mockolate.sln.DotSettings
+++ b/aweXpect.Mockolate.sln.DotSettings
@@ -1,9 +1,15 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/LOCAL_FUNCTION_BODY/@EntryValue">ExpressionBody</s:String>
+﻿<wpf:ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib"
+						xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+						xml:space="preserve">
+	<s:String
+		x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/LOCAL_FUNCTION_BODY/@EntryValue">ExpressionBody</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/METHOD_OR_OPERATOR_BODY/@EntryValue">ExpressionBody</s:String>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_DECLARATION_BLOCK_ARRANGEMENT/@EntryValue">True</s:Boolean>
-	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_INITIALIZER_ELEMENTS_ON_LINE/@EntryValue">1</s:Int64>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_INITIALIZER_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
+	<s:Boolean
+		x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_DECLARATION_BLOCK_ARRANGEMENT/@EntryValue">True</s:Boolean>
+	<s:Int64
+		x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_INITIALIZER_ELEMENTS_ON_LINE/@EntryValue">1</s:Int64>
+	<s:Boolean
+		x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_INITIALIZER_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_ARROW_WITH_EXPRESSIONS/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
   &lt;TypePattern DisplayName="Non-reorderable types" Priority="99999999"&gt;&#xD;
@@ -217,11 +223,16 @@
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
 &lt;/Patterns&gt;</s:String>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002EMemberReordering_002EMigrations_002ECSharpFileLayoutPatternRemoveIsAttributeUpgrade/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean
+		x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean
+		x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean
+		x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean
+		x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002EMemberReordering_002EMigrations_002ECSharpFileLayoutPatternRemoveIsAttributeUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean
+		x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=awexpect/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nupkg/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mockolate/@EntryIndexedValue">True</s:Boolean>

--- a/aweXpect.Mockolate.slnx
+++ b/aweXpect.Mockolate.slnx
@@ -1,39 +1,39 @@
 <Solution>
-  <Folder Name="/Benchmarks/">
-    <Project Path="Benchmarks/aweXpect.Mockolate.Benchmarks/aweXpect.Mockolate.Benchmarks.csproj" />
-  </Folder>
-  <Folder Name="/Pipeline/">
-    <Project Path="Pipeline/Build.csproj" />
-  </Folder>
-  <Folder Name="/Tests/">
-    <Project Path="Tests/aweXpect.Mockolate.Api.Tests/aweXpect.Mockolate.Api.Tests.csproj" />
-    <Project Path="Tests/aweXpect.Mockolate.Tests/aweXpect.Mockolate.Tests.csproj" />
-  </Folder>
-  <Folder Name="/_/">
-    <File Path=".editorconfig" />
-    <File Path=".gitattributes" />
-    <File Path=".gitignore" />
-    <File Path="aweXpect.Mockolate.sln.DotSettings" />
-    <File Path="CODE_OF_CONDUCT.md" />
-    <File Path="CONTRIBUTING.md" />
-    <File Path="Directory.Build.props" />
-    <File Path="Directory.Packages.props" />
-    <File Path="global.json" />
-    <File Path="LICENSE" />
-    <File Path="nuget.config" />
-    <File Path="README.md" />
-  </Folder>
-  <Folder Name="/_/.github/" />
-  <Folder Name="/_/.github/workflows/">
-    <File Path=".github/workflows/build.yml" />
-    <File Path=".github/workflows/ci-analysis.yml" />
-    <File Path=".github/workflows/ci.yml" />
-  </Folder>
-  <Folder Name="/_/Source/">
-    <File Path="Source/Directory.Build.props" />
-  </Folder>
-  <Folder Name="/_/Tests/">
-    <File Path="Tests/Directory.Build.props" />
-  </Folder>
-  <Project Path="Source/aweXpect.Mockolate/aweXpect.Mockolate.csproj" />
+	<Folder Name="/Benchmarks/">
+		<Project Path="Benchmarks/aweXpect.Mockolate.Benchmarks/aweXpect.Mockolate.Benchmarks.csproj"/>
+	</Folder>
+	<Folder Name="/Pipeline/">
+		<Project Path="Pipeline/Build.csproj"/>
+	</Folder>
+	<Folder Name="/Tests/">
+		<Project Path="Tests/aweXpect.Mockolate.Api.Tests/aweXpect.Mockolate.Api.Tests.csproj"/>
+		<Project Path="Tests/aweXpect.Mockolate.Tests/aweXpect.Mockolate.Tests.csproj"/>
+	</Folder>
+	<Folder Name="/_/">
+		<File Path=".editorconfig"/>
+		<File Path=".gitattributes"/>
+		<File Path=".gitignore"/>
+		<File Path="aweXpect.Mockolate.sln.DotSettings"/>
+		<File Path="CODE_OF_CONDUCT.md"/>
+		<File Path="CONTRIBUTING.md"/>
+		<File Path="Directory.Build.props"/>
+		<File Path="Directory.Packages.props"/>
+		<File Path="global.json"/>
+		<File Path="LICENSE"/>
+		<File Path="nuget.config"/>
+		<File Path="README.md"/>
+	</Folder>
+	<Folder Name="/_/.github/"/>
+	<Folder Name="/_/.github/workflows/">
+		<File Path=".github/workflows/build.yml"/>
+		<File Path=".github/workflows/ci-analysis.yml"/>
+		<File Path=".github/workflows/ci.yml"/>
+	</Folder>
+	<Folder Name="/_/Source/">
+		<File Path="Source/Directory.Build.props"/>
+	</Folder>
+	<Folder Name="/_/Tests/">
+		<File Path="Tests/Directory.Build.props"/>
+	</Folder>
+	<Project Path="Source/aweXpect.Mockolate/aweXpect.Mockolate.csproj"/>
 </Solution>


### PR DESCRIPTION
This pull request contains a variety of small improvements and cleanups across the codebase, primarily focused on code formatting, consistency, and minor refactoring. The most significant changes address EditorConfig settings, code style, and a few code logic adjustments.

**Formatting and Code Style Improvements:**

* Added `charset = utf-8` and `trim_trailing_whitespace = true` to `.editorconfig` to enforce consistent encoding and whitespace handling across the project.

**Code Quality and Refactoring:**

* Made `DisableMutationTests` a `readonly` field in `Build.MutationTests.cs` to clarify its immutability.
* Reformatted long lines and improved readability in conditional and method calls, such as in `Build.Pack.cs` and `ThatMockVerify.AllSetupsAreUsed.cs`.
* Minor logic and whitespace adjustments in mutation test pipeline scripts for better maintainability.

No functional changes have been introduced; these updates are intended to improve maintainability and code consistency.