### PR TITLE
feat: include all interactions in failure message

### DIFF
--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Between.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Between.cs
@@ -74,13 +74,18 @@ public static partial class ThatVerificationResult
 					{
 						string interactionsText = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 						expectationBuilder.UpdateContexts(contexts => contexts
-							.Remove("Interactions")
-							.Add(new ResultContext.SyncCallback("Interactions", () => interactionsText)));
+							.Remove("Matching Interactions")
+							.Add(new ResultContext.SyncCallback("Matching Interactions", () => interactionsText)));
 						_count = interactions.Length;
 						return interactions.Length >= minimum && interactions.Length <= maximum;
 					})
 						? Outcome.Success
 						: Outcome.Failure;
+					if (Outcome == Outcome.Failure)
+					{
+						AppendAllInteractions(expectationBuilder,
+							((IVerificationResult<TVerify>)actual).Object as IMock);
+					}
 					return this;
 				}
 				catch (MockVerificationTimeoutException)
@@ -88,8 +93,8 @@ public static partial class ThatVerificationResult
 					string interactionsText = Formatter.Format(((IVerificationResult)actual).MockInteractions,
 						FormattingOptions.MultipleLines);
 					expectationBuilder.UpdateContexts(contexts => contexts
-						.Remove("Interactions")
-						.Add(new ResultContext.SyncCallback("Interactions",
+						.Remove("Matching Interactions")
+						.Add(new ResultContext.SyncCallback("Matching Interactions",
 							() => interactionsText)));
 					Outcome = Outcome.Failure;
 					return this;
@@ -103,12 +108,17 @@ public static partial class ThatVerificationResult
 			{
 				string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 				expectationBuilder.UpdateContexts(contexts => contexts.Add(
-					new ResultContext.SyncCallback("Interactions", () => context)));
+					new ResultContext.SyncCallback("Matching Interactions", () => context)));
 				_count = interactions.Length;
 				return interactions.Length >= minimum && interactions.Length <= maximum;
 			})
 				? Outcome.Success
 				: Outcome.Failure;
+			if (Outcome == Outcome.Failure)
+			{
+				AppendAllInteractions(expectationBuilder,
+					((IVerificationResult<TVerify>)actual).Object as IMock);
+			}
 			return this;
 		}
 

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
@@ -63,7 +63,9 @@ public static partial class ThatVerificationResult
 				string context = Formatter.Format(((IVerificationResult)actual).MockInteractions,
 					FormattingOptions.MultipleLines);
 				expectationBuilder.UpdateContexts(contexts => contexts.Add(
-					new ResultContext.SyncCallback("Interactions", () => context)));
+					new ResultContext.SyncCallback("Matching Interactions", () => context)));
+				AppendAllInteractions(expectationBuilder,
+					((IVerificationResult<T>)actual).Object as IMock);
 			}
 
 			return this;

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Times.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Times.cs
@@ -74,13 +74,18 @@ public static partial class ThatVerificationResult
 					{
 						string interactionsText = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 						expectationBuilder.UpdateContexts(contexts => contexts
-							.Remove("Interactions")
-							.Add(new ResultContext.SyncCallback("Interactions", () => interactionsText)));
+							.Remove("Matching Interactions")
+							.Add(new ResultContext.SyncCallback("Matching Interactions", () => interactionsText)));
 						_count = interactions.Length;
 						return predicate(_count);
 					})
 						? Outcome.Success
 						: Outcome.Failure;
+					if (Outcome == Outcome.Failure)
+					{
+						AppendAllInteractions(expectationBuilder,
+							((IVerificationResult<TVerify>)actual).Object as IMock);
+					}
 					return this;
 				}
 				catch (MockVerificationTimeoutException)
@@ -88,8 +93,8 @@ public static partial class ThatVerificationResult
 					string interactionsText = Formatter.Format(((IVerificationResult)actual).MockInteractions,
 						FormattingOptions.MultipleLines);
 					expectationBuilder.UpdateContexts(contexts => contexts
-						.Remove("Interactions")
-						.Add(new ResultContext.SyncCallback("Interactions",
+						.Remove("Matching Interactions")
+						.Add(new ResultContext.SyncCallback("Matching Interactions",
 							() => interactionsText)));
 					Outcome = Outcome.Failure;
 					return this;
@@ -103,12 +108,17 @@ public static partial class ThatVerificationResult
 			{
 				string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 				expectationBuilder.UpdateContexts(contexts => contexts.Add(
-					new ResultContext.SyncCallback("Interactions", () => context)));
+					new ResultContext.SyncCallback("Matching Interactions", () => context)));
 				_count = interactions.Length;
 				return predicate(_count);
 			})
 				? Outcome.Success
 				: Outcome.Failure;
+			if (Outcome == Outcome.Failure)
+			{
+				AppendAllInteractions(expectationBuilder,
+					((IVerificationResult<TVerify>)actual).Object as IMock);
+			}
 			return this;
 		}
 

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.cs
@@ -8,6 +8,7 @@ using aweXpect.Helpers;
 using aweXpect.Options;
 using Mockolate;
 using Mockolate.Exceptions;
+using Mockolate.Interactions;
 using Mockolate.Verify;
 
 namespace aweXpect;
@@ -25,6 +26,20 @@ public static partial class ThatVerificationResult
 			2 => "twice",
 			_ => $"{number} times",
 		};
+
+	private static void AppendAllInteractions(ExpectationBuilder expectationBuilder, IMock? mock)
+	{
+		if (mock is null)
+		{
+			return;
+		}
+
+		MockInteractions allInteractions = mock.MockRegistry.Interactions;
+		string interactionsText = Formatter.Format(allInteractions, FormattingOptions.MultipleLines);
+		expectationBuilder.UpdateContexts(contexts => contexts
+			.Remove("All Interactions")
+			.Add(new ResultContext.SyncCallback("All Interactions", () => interactionsText)));
+	}
 
 	private sealed class HasExactlyConstraint<TVerify>(
 		ExpectationBuilder expectationBuilder,
@@ -65,13 +80,19 @@ public static partial class ThatVerificationResult
 					{
 						string interactionsText = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 						expectationBuilder.UpdateContexts(contexts => contexts
-							.Remove("Interactions")
-							.Add(new ResultContext.SyncCallback("Interactions", () => interactionsText)));
+							.Remove("Matching Interactions")
+							.Add(new ResultContext.SyncCallback("Matching Interactions", () => interactionsText)));
 						_count = interactions.Length;
 						return interactions.Length == expected;
 					})
 						? Outcome.Success
 						: Outcome.Failure;
+					if (Outcome == Outcome.Failure)
+					{
+						AppendAllInteractions(expectationBuilder,
+							((IVerificationResult<TVerify>)actual).Object as IMock);
+					}
+
 					return this;
 				}
 				catch (MockVerificationTimeoutException)
@@ -79,8 +100,8 @@ public static partial class ThatVerificationResult
 					string interactionsText = Formatter.Format(((IVerificationResult)actual).MockInteractions,
 						FormattingOptions.MultipleLines);
 					expectationBuilder.UpdateContexts(contexts => contexts
-						.Remove("Interactions")
-						.Add(new ResultContext.SyncCallback("Interactions",
+						.Remove("Matching Interactions")
+						.Add(new ResultContext.SyncCallback("Matching Interactions",
 							() => interactionsText)));
 					Outcome = Outcome.Failure;
 					return this;
@@ -94,12 +115,17 @@ public static partial class ThatVerificationResult
 			{
 				string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 				expectationBuilder.UpdateContexts(contexts => contexts.Add(
-					new ResultContext.SyncCallback("Interactions", () => context)));
+					new ResultContext.SyncCallback("Matching Interactions", () => context)));
 				_count = interactions.Length;
 				return interactions.Length == expected;
 			})
 				? Outcome.Success
 				: Outcome.Failure;
+			if (Outcome == Outcome.Failure)
+			{
+				AppendAllInteractions(expectationBuilder, ((IVerificationResult<TVerify>)actual).Object as IMock);
+			}
+
 			return this;
 		}
 
@@ -177,12 +203,17 @@ public static partial class ThatVerificationResult
 			{
 				string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 				expectationBuilder.UpdateContexts(contexts => contexts.Add(
-					new ResultContext.SyncCallback("Interactions", () => context)));
+					new ResultContext.SyncCallback("Matching Interactions", () => context)));
 				_count = interactions.Length;
 				return interactions.Length <= expected;
 			})
 				? Outcome.Success
 				: Outcome.Failure;
+			if (Outcome == Outcome.Failure)
+			{
+				AppendAllInteractions(expectationBuilder,
+					((IVerificationResult<TVerify>)actual).Object as IMock);
+			}
 			return this;
 		}
 
@@ -260,13 +291,18 @@ public static partial class ThatVerificationResult
 					{
 						string interactionsText = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 						expectationBuilder.UpdateContexts(contexts => contexts
-							.Remove("Interactions")
-							.Add(new ResultContext.SyncCallback("Interactions", () => interactionsText)));
+							.Remove("Matching Interactions")
+							.Add(new ResultContext.SyncCallback("Matching Interactions", () => interactionsText)));
 						_count = interactions.Length;
 						return interactions.Length >= expected;
 					})
 						? Outcome.Success
 						: Outcome.Failure;
+					if (Outcome == Outcome.Failure)
+					{
+						AppendAllInteractions(expectationBuilder,
+							((IVerificationResult<TVerify>)actual).Object as IMock);
+					}
 					return this;
 				}
 				catch (MockVerificationTimeoutException)
@@ -274,8 +310,8 @@ public static partial class ThatVerificationResult
 					string interactionsText = Formatter.Format(((IVerificationResult)actual).MockInteractions,
 						FormattingOptions.MultipleLines);
 					expectationBuilder.UpdateContexts(contexts => contexts
-						.Remove("Interactions")
-						.Add(new ResultContext.SyncCallback("Interactions",
+						.Remove("Matching Interactions")
+						.Add(new ResultContext.SyncCallback("Matching Interactions",
 							() => interactionsText)));
 					Outcome = Outcome.Failure;
 					return this;
@@ -289,12 +325,17 @@ public static partial class ThatVerificationResult
 			{
 				string context = Formatter.Format(interactions, FormattingOptions.MultipleLines);
 				expectationBuilder.UpdateContexts(contexts => contexts
-					.Add(new ResultContext.SyncCallback("Interactions", () => context)));
+					.Add(new ResultContext.SyncCallback("Matching Interactions", () => context)));
 				_count = interactions.Length;
 				return interactions.Length >= expected;
 			})
 				? Outcome.Success
 				: Outcome.Failure;
+			if (Outcome == Outcome.Failure)
+			{
+				AppendAllInteractions(expectationBuilder,
+					((IVerificationResult<TVerify>)actual).Object as IMock);
+			}
 			return this;
 		}
 

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastOnceTests.cs
@@ -44,7 +44,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) at least once,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 			cts.Cancel();
@@ -147,7 +150,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) at least once,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 		}
@@ -202,7 +208,7 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) at least once,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, True),
 				               [1] invoke method MyMethod(2, True)
@@ -245,7 +251,7 @@ public sealed partial class ThatVerificationResultIs
 					             invoked method MyMethod(1, false) less than once,
 					             but found it once
 
-					             Interactions:
+					             Matching Interactions:
 					             [
 					               [0] invoke method MyMethod(1, False)
 					             ]
@@ -272,7 +278,7 @@ public sealed partial class ThatVerificationResultIs
 					             invoked method MyMethod(1, false) less than once,
 					             but found it twice
 
-					             Interactions:
+					             Matching Interactions:
 					             [
 					               [0] invoke method MyMethod(1, False),
 					               [1] invoke method MyMethod(1, False)

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTests.cs
@@ -53,7 +53,7 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) at least {times} times,
 				              but found it only {invocationTimes} times
 
-				              Interactions:
+				              Matching Interactions:
 				              [
 				              *
 				              ]
@@ -95,7 +95,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) at least 3 times,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 			cts.Cancel();
@@ -204,7 +207,10 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) at least {times} times,
 				              but never found it
 
-				              Interactions:
+				              Matching Interactions:
+				              []
+
+				              All Interactions:
 				              []
 				              """);
 		}
@@ -229,7 +235,7 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(It.IsAny<int>(), true) at least 4 times,
 				             but found it only 3 times
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, True),
 				               [1] invoke method MyMethod(2, True),
@@ -264,7 +270,7 @@ public sealed partial class ThatVerificationResultIs
 					              invoked method MyMethod(1, false) less than {times} times,
 					              but found it {invocationTimes} times
 
-					              Interactions:
+					              Matching Interactions:
 					              [
 					              *
 					              ]

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtLeastTwiceTests.cs
@@ -44,7 +44,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) at least twice,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 			cts.Cancel();
@@ -147,7 +150,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) at least twice,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 		}
@@ -170,7 +176,12 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) at least twice,
 				             but found it only once
 
-				             Interactions:
+				             Matching Interactions:
+				             [
+				               [0] invoke method MyMethod(1, False)
+				             ]
+
+				             All Interactions:
 				             [
 				               [0] invoke method MyMethod(1, False)
 				             ]
@@ -213,7 +224,7 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(2, true) at least twice,
 				             but found it only once
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, True),
 				               [1] invoke method MyMethod(2, True),

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostOnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostOnceTests.cs
@@ -27,7 +27,14 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) at most once,
 				             but found it 3 times
 
-				             Interactions:
+				             Matching Interactions:
+				             [
+				               [0] invoke method MyMethod(1, False),
+				               [1] invoke method MyMethod(1, False),
+				               [2] invoke method MyMethod(1, False)
+				             ]
+
+				             All Interactions:
 				             [
 				               [0] invoke method MyMethod(1, False),
 				               [1] invoke method MyMethod(1, False),
@@ -71,6 +78,7 @@ public sealed partial class ThatVerificationResultIs
 
 			sut.MyMethod(1, false);
 			sut.MyMethod(1, false);
+			sut.MyMethod(2, false);
 
 			async Task Act()
 			{
@@ -83,10 +91,17 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) at most once,
 				             but found it twice
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, False),
 				               [1] invoke method MyMethod(1, False)
+				             ]
+
+				             All Interactions:
+				             [
+				               [0] invoke method MyMethod(1, False),
+				               [1] invoke method MyMethod(1, False),
+				               [2] invoke method MyMethod(2, False)
 				             ]
 				             """);
 		}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTests.cs
@@ -30,7 +30,7 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) at most never,
 				              but found it {amountString}
 
-				              Interactions:
+				              Matching Interactions:
 				              [
 				              *
 				              ]
@@ -102,7 +102,7 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) at most {times} times,
 				              but found it {invocationTimes} times
 
-				              Interactions:
+				              Matching Interactions:
 				              [
 				              *
 				              ]
@@ -135,7 +135,7 @@ public sealed partial class ThatVerificationResultIs
 					              invoked method MyMethod(1, false) more than {times} times,
 					              but found it only {invocationTimes} times
 
-					              Interactions:
+					              Matching Interactions:
 					              [
 					              *
 					              ]
@@ -180,7 +180,7 @@ public sealed partial class ThatVerificationResultIs
 					             invoked method MyMethod(1, false) more than 3 times,
 					             but never found it
 
-					             Interactions:
+					             Matching Interactions:
 					             []
 					             """);
 			}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.AtMostTwiceTests.cs
@@ -15,6 +15,7 @@ public sealed partial class ThatVerificationResultIs
 			sut.MyMethod(1, false);
 			sut.MyMethod(1, false);
 			sut.MyMethod(1, false);
+			sut.MyMethod(2, false);
 
 			async Task Act()
 			{
@@ -27,11 +28,19 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) at most twice,
 				             but found it 3 times
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, False),
 				               [1] invoke method MyMethod(1, False),
 				               [2] invoke method MyMethod(1, False)
+				             ]
+
+				             All Interactions:
+				             [
+				               [0] invoke method MyMethod(1, False),
+				               [1] invoke method MyMethod(1, False),
+				               [2] invoke method MyMethod(1, False),
+				               [3] invoke method MyMethod(2, False)
 				             ]
 				             """);
 		}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.BetweenTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.BetweenTests.cs
@@ -45,7 +45,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) between 3 and 6 times,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 			cts.Cancel();
@@ -163,7 +166,10 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) between {minimum} and {maximum} times,
 				              but never found it
 
-				              Interactions:
+				              Matching Interactions:
+				              []
+
+				              All Interactions:
 				              []
 				              """);
 		}
@@ -191,7 +197,7 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) between {minimum} and {maximum} times,
 				              but found it only {invocationTimes} times
 
-				              Interactions:
+				              Matching Interactions:
 				              [
 				              *
 				              ]
@@ -221,7 +227,7 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) between {minimum} and {maximum} times,
 				              but found it {invocationTimes} times
 
-				              Interactions:
+				              Matching Interactions:
 				              [
 				              *
 				              ]
@@ -249,7 +255,7 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(It.IsAny<int>(), true) between 4 and 6 times,
 				             but found it only 3 times
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, True),
 				               [1] invoke method MyMethod(2, True),
@@ -285,7 +291,7 @@ public sealed partial class ThatVerificationResultIs
 					              invoked method MyMethod(1, false) not between {minimum} and {maximum} times,
 					              but found it {invocationTimes} times
 
-					              Interactions:
+					              Matching Interactions:
 					              [
 					              *
 					              ]

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ExactlyTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ExactlyTests.cs
@@ -54,7 +54,7 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) exactly {times} times,
 				              but found it only {invocationTimes} times
 
-				              Interactions:
+				              Matching Interactions:
 				              [
 				              *
 				              ]
@@ -96,7 +96,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) exactly 3 times,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 			cts.Cancel();
@@ -189,7 +192,7 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) exactly {times} times,
 				              but found it {invocationTimes} times
 
-				              Interactions:
+				              Matching Interactions:
 				              [
 				              *
 				              ]
@@ -215,7 +218,10 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) exactly {times} times,
 				              but never found it
 
-				              Interactions:
+				              Matching Interactions:
+				              []
+
+				              All Interactions:
 				              []
 				              """);
 		}
@@ -242,7 +248,7 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(It.IsAny<int>(), true) exactly 3 times,
 				             but found it 4 times
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, True),
 				               [1] invoke method MyMethod(2, True),
@@ -278,7 +284,7 @@ public sealed partial class ThatVerificationResultIs
 					              invoked method MyMethod(1, false) not exactly {times} times,
 					              but it was
 
-					              Interactions:
+					              Matching Interactions:
 					              [
 					              *
 					              ]

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.NeverTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.NeverTests.cs
@@ -14,6 +14,7 @@ public sealed partial class ThatVerificationResultIs
 
 			sut.MyMethod(1, false);
 			sut.MyMethod(1, false);
+			sut.MyMethod(2, false);
 			sut.MyMethod(1, false);
 
 			async Task Act()
@@ -27,11 +28,19 @@ public sealed partial class ThatVerificationResultIs
 				             never invoked method MyMethod(1, false),
 				             but found it 3 times
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, False),
 				               [1] invoke method MyMethod(1, False),
-				               [2] invoke method MyMethod(1, False)
+				               [3] invoke method MyMethod(1, False)
+				             ]
+
+				             All Interactions:
+				             [
+				               [0] invoke method MyMethod(1, False),
+				               [1] invoke method MyMethod(1, False),
+				               [2] invoke method MyMethod(2, False),
+				               [3] invoke method MyMethod(1, False)
 				             ]
 				             """);
 		}
@@ -67,7 +76,12 @@ public sealed partial class ThatVerificationResultIs
 				             never invoked method MyMethod(1, false),
 				             but found it once
 
-				             Interactions:
+				             Matching Interactions:
+				             [
+				               [0] invoke method MyMethod(1, False)
+				             ]
+
+				             All Interactions:
 				             [
 				               [0] invoke method MyMethod(1, False)
 				             ]
@@ -93,7 +107,13 @@ public sealed partial class ThatVerificationResultIs
 				             never invoked method MyMethod(1, false),
 				             but found it twice
 
-				             Interactions:
+				             Matching Interactions:
+				             [
+				               [0] invoke method MyMethod(1, False),
+				               [1] invoke method MyMethod(1, False)
+				             ]
+
+				             All Interactions:
 				             [
 				               [0] invoke method MyMethod(1, False),
 				               [1] invoke method MyMethod(1, False)

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.OnceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.OnceTests.cs
@@ -44,7 +44,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) exactly once,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 			cts.Cancel();
@@ -130,7 +133,14 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) exactly once,
 				             but found it 3 times
 
-				             Interactions:
+				             Matching Interactions:
+				             [
+				               [0] invoke method MyMethod(1, False),
+				               [1] invoke method MyMethod(1, False),
+				               [2] invoke method MyMethod(1, False)
+				             ]
+
+				             All Interactions:
 				             [
 				               [0] invoke method MyMethod(1, False),
 				               [1] invoke method MyMethod(1, False),
@@ -156,7 +166,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) exactly once,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 		}
@@ -183,6 +196,7 @@ public sealed partial class ThatVerificationResultIs
 
 			sut.MyMethod(1, false);
 			sut.MyMethod(1, false);
+			sut.MyMethod(2, false);
 
 			async Task Act()
 			{
@@ -195,10 +209,17 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) exactly once,
 				             but found it twice
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, False),
 				               [1] invoke method MyMethod(1, False)
+				             ]
+
+				             All Interactions:
+				             [
+				               [0] invoke method MyMethod(1, False),
+				               [1] invoke method MyMethod(1, False),
+				               [2] invoke method MyMethod(2, False)
 				             ]
 				             """);
 		}
@@ -219,7 +240,7 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(It.IsAny<int>(), true) exactly once,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
 				             []
 				             """);
 		}

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
@@ -27,7 +27,15 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1) in order,
 				             but it invoked method MyMethod(1) too early
 
-				             Interactions:
+				             Matching Interactions:
+				             [
+				               [0] invoke method MyMethod(1),
+				               [1] invoke method MyMethod(2),
+				               [2] invoke method MyMethod(3),
+				               [3] invoke method MyMethod(4)
+				             ]
+
+				             All Interactions:
 				             [
 				               [0] invoke method MyMethod(1),
 				               [1] invoke method MyMethod(2),
@@ -58,7 +66,15 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(4) in order,
 				             but it invoked method MyMethod(6) not at all
 
-				             Interactions:
+				             Matching Interactions:
+				             [
+				               [0] invoke method MyMethod(1),
+				               [1] invoke method MyMethod(2),
+				               [2] invoke method MyMethod(3),
+				               [3] invoke method MyMethod(4)
+				             ]
+
+				             All Interactions:
 				             [
 				               [0] invoke method MyMethod(1),
 				               [1] invoke method MyMethod(2),
@@ -77,7 +93,15 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(3) in order,
 				             but it invoked method MyMethod(6) not at all
 
-				             Interactions:
+				             Matching Interactions:
+				             [
+				               [0] invoke method MyMethod(1),
+				               [1] invoke method MyMethod(2),
+				               [2] invoke method MyMethod(3),
+				               [3] invoke method MyMethod(4)
+				             ]
+
+				             All Interactions:
 				             [
 				               [0] invoke method MyMethod(1),
 				               [1] invoke method MyMethod(2),
@@ -96,7 +120,15 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(6) in order,
 				             but it invoked method MyMethod(6) not at all
 
-				             Interactions:
+				             Matching Interactions:
+				             [
+				               [0] invoke method MyMethod(1),
+				               [1] invoke method MyMethod(2),
+				               [2] invoke method MyMethod(3),
+				               [3] invoke method MyMethod(4)
+				             ]
+
+				             All Interactions:
 				             [
 				               [0] invoke method MyMethod(1),
 				               [1] invoke method MyMethod(2),

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
@@ -43,7 +43,7 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) according to the predicate n => n % 2 == 0,
 				              but {expectedFoundTimes}
 
-				              Interactions:
+				              Matching Interactions:
 				              [*]
 				              """).AsWildcard();
 		}
@@ -82,7 +82,7 @@ public sealed partial class ThatVerificationResultIs
 				              invoked method MyMethod(1, false) according to the predicate n => n % 2 == 1,
 				              but {expectedFoundTimes}
 
-				              Interactions:
+				              Matching Interactions:
 				              [*]
 				              """).AsWildcard();
 		}
@@ -122,7 +122,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) according to the predicate n => n % 3 == 2,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 			cts.Cancel();
@@ -222,7 +225,7 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(It.IsAny<int>(), true) according to the predicate x => x != 4,
 				             but found it 4 times
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, True),
 				               [1] invoke method MyMethod(2, True),

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TwiceTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TwiceTests.cs
@@ -44,7 +44,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) exactly twice,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 			cts.Cancel();
@@ -117,6 +120,7 @@ public sealed partial class ThatVerificationResultIs
 
 			sut.MyMethod(1, false);
 			sut.MyMethod(1, false);
+			sut.MyMethod(2, true);
 			sut.MyMethod(1, false);
 
 			async Task Act()
@@ -130,11 +134,19 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) exactly twice,
 				             but found it 3 times
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, False),
 				               [1] invoke method MyMethod(1, False),
-				               [2] invoke method MyMethod(1, False)
+				               [3] invoke method MyMethod(1, False)
+				             ]
+
+				             All Interactions:
+				             [
+				               [0] invoke method MyMethod(1, False),
+				               [1] invoke method MyMethod(1, False),
+				               [2] invoke method MyMethod(2, True),
+				               [3] invoke method MyMethod(1, False)
 				             ]
 				             """);
 		}
@@ -156,7 +168,10 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) exactly twice,
 				             but never found it
 
-				             Interactions:
+				             Matching Interactions:
+				             []
+
+				             All Interactions:
 				             []
 				             """);
 		}
@@ -179,7 +194,12 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(1, false) exactly twice,
 				             but found it only once
 
-				             Interactions:
+				             Matching Interactions:
+				             [
+				               [0] invoke method MyMethod(1, False)
+				             ]
+
+				             All Interactions:
 				             [
 				               [0] invoke method MyMethod(1, False)
 				             ]
@@ -223,7 +243,7 @@ public sealed partial class ThatVerificationResultIs
 				             invoked method MyMethod(3, true) exactly twice,
 				             but found it only once
 
-				             Interactions:
+				             Matching Interactions:
 				             [
 				               [0] invoke method MyMethod(1, True),
 				               [1] invoke method MyMethod(2, True),

--- a/Tests/aweXpect.Mockolate.Tests/Web/ItExtensionsTests.HttpContentTests.IsJsonContentTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/Web/ItExtensionsTests.HttpContentTests.IsJsonContentTests.cs
@@ -543,9 +543,9 @@ public sealed partial class ItExtensionsTests
 					HttpClient httpClient = HttpClient.CreateMock();
 					httpClient.Mock.Setup
 						.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithJsonMatching(new
-						{
-							foo = 1,
-						},
+							{
+								foo = 1,
+							},
 							new JsonDocumentOptions
 							{
 								AllowTrailingCommas = allowTrailingCommas,


### PR DESCRIPTION
This pull request improves the clarity and usefulness of mock verification failure messages by consistently renaming the "Interactions" context to "Matching Interactions" and, when a verification fails, adding a new "All Interactions" context to the output. This gives users better insight into both the interactions that matched the verification and all interactions that occurred on the mock. The changes also update tests to reflect the new output format.

**Enhancements to failure diagnostics:**

* Added a new `AppendAllInteractions` helper method to append all recorded interactions to the expectation builder when a verification fails, making it easier to debug why a verification did not pass. 

**Consistency and clarity improvements:**

* Renamed all usages of the "Interactions" context to "Matching Interactions" across the codebase for clarity and consistency, ensuring that the output clearly distinguishes between interactions that matched the verification and all interactions.

**Test updates:**

* Updated test expectations to check for the new "Matching Interactions" and "All Interactions" sections in verification failure messages, ensuring tests align with the improved diagnostic output.

---

- *Fixes #77*