### PR TITLE
coverage: add tests for chained matchers and negated verification scenarios

### DIFF
--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.NeverTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.NeverTests.cs
@@ -120,5 +120,46 @@ public sealed partial class ThatVerificationResultIs
 				             ]
 				             """);
 		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenInvokedNever_ShouldFail()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.Never());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+					             invoked method MyMethod(1, false) at least once,
+					             but it was
+
+					             Matching Interactions:
+					             []
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenInvokedOnce_ShouldSucceed()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				sut.MyMethod(1, false);
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.Never());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
@@ -137,5 +137,75 @@ public sealed partial class ThatVerificationResultIs
 				             ]
 				             """);
 		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenInteractionsAreInOrder_ShouldFail()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				sut.MyMethod(1);
+				sut.MyMethod(2);
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1)))
+						.DoesNotComplyWith(it => it.Then(m => m.MyMethod(It.Is(2))));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+					             invoked method MyMethod(1), then
+					             invoked method MyMethod(2) not in order,
+					             but it did
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenInteractionsAreNotInOrder_ShouldSucceed()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				sut.MyMethod(2);
+				sut.MyMethod(1);
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1)))
+						.DoesNotComplyWith(it => it.Then(m => m.MyMethod(It.Is(2))));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithMultipleInteractionsInOrder_ShouldFail()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				sut.MyMethod(1);
+				sut.MyMethod(2);
+				sut.MyMethod(3);
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1)))
+						.DoesNotComplyWith(it => it.Then(
+							m => m.MyMethod(It.Is(2)),
+							m => m.MyMethod(It.Is(3))));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+					             invoked method MyMethod(1), then
+					             invoked method MyMethod(2), then
+					             invoked method MyMethod(3) not in order,
+					             but it did
+					             """);
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.TimesTests.cs
@@ -234,5 +234,52 @@ public sealed partial class ThatVerificationResultIs
 				             ]
 				             """);
 		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenPredicateDoesNotMatch_ShouldSucceed()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				sut.MyMethod(1, false);
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.Times(n => n == 2));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPredicateMatches_ShouldFail()
+			{
+				IMyService sut = IMyService.CreateMock();
+
+				sut.MyMethod(1, false);
+				sut.MyMethod(1, false);
+
+				async Task Act()
+				{
+					await That(sut.Mock.Verify.MyMethod(It.Is(1), It.Is(false)))
+						.DoesNotComplyWith(it => it.Times(n => n == 2));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that the aweXpect.Mockolate.Tests.ThatVerificationResultIs.IMyService mock
+					             invoked method MyMethod(1, false) not according to the predicate n => n == 2,
+					             but found it twice
+
+					             Matching Interactions:
+					             [
+					               [0] invoke method MyMethod(1, False),
+					               [1] invoke method MyMethod(1, False)
+					             ]
+					             """);
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Mockolate.Tests/Web/ItExtensionsTests.HttpContentTests.IsJsonContentTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/Web/ItExtensionsTests.HttpContentTests.IsJsonContentTests.cs
@@ -560,6 +560,151 @@ public sealed partial class ItExtensionsTests
 						.IsEqualTo(allowTrailingCommas ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
 				}
 			}
+
+			public sealed class ChainedMatcherTests
+			{
+				[Theory]
+				[InlineData("application/json", true)]
+				[InlineData("text/plain", false)]
+				public async Task WithMediaType_ShouldForwardToInnerParameter(string expectedMediaType,
+					bool expectSuccess)
+				{
+					HttpClient httpClient = HttpClient.CreateMock();
+					httpClient.Mock.Setup
+						.PostAsync(It.IsAny<Uri>(),
+							It.IsHttpContent().WithJsonMatching(new
+							{
+								foo = 1,
+							}).WithMediaType(expectedMediaType))
+						.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+					StringContent content = new("{\"foo\": 1}", System.Text.Encoding.UTF8, "application/json");
+					HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+						content,
+						CancellationToken.None);
+
+					await That(result.StatusCode)
+						.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
+				}
+
+				[Theory]
+				[InlineData(true)]
+				[InlineData(false)]
+				public async Task WithString_ShouldForwardToInnerParameter(bool predicateResult)
+				{
+					HttpClient httpClient = HttpClient.CreateMock();
+					httpClient.Mock.Setup
+						.PostAsync(It.IsAny<Uri>(),
+							It.IsHttpContent().WithJsonMatching(new
+							{
+								foo = 1,
+							}).WithString(_ => predicateResult))
+						.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+					HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+						new StringContent("{\"foo\": 1}"),
+						CancellationToken.None);
+
+					await That(result.StatusCode)
+						.IsEqualTo(predicateResult ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
+				}
+
+				[Theory]
+				[InlineData(true)]
+				[InlineData(false)]
+				public async Task WithBytes_ShouldForwardToInnerParameter(bool predicateResult)
+				{
+					HttpClient httpClient = HttpClient.CreateMock();
+					httpClient.Mock.Setup
+						.PostAsync(It.IsAny<Uri>(),
+							It.IsHttpContent().WithJsonMatching(new
+							{
+								foo = 1,
+							}).WithBytes(_ => predicateResult))
+						.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+					HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+						new StringContent("{\"foo\": 1}"),
+						CancellationToken.None);
+
+					await That(result.StatusCode)
+						.IsEqualTo(predicateResult ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
+				}
+
+				[Theory]
+				[InlineData("expected-value", true)]
+				[InlineData("other-value", false)]
+				public async Task WithHeaders_ShouldForwardToInnerParameter(string requiredHeaderValue,
+					bool expectSuccess)
+				{
+					HttpClient httpClient = HttpClient.CreateMock();
+					httpClient.Mock.Setup
+						.PostAsync(It.IsAny<Uri>(),
+							It.IsHttpContent().WithJsonMatching(new
+							{
+								foo = 1,
+							}).WithHeaders(("X-Custom", new HttpHeaderValue(requiredHeaderValue))))
+						.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+					StringContent content = new("{\"foo\": 1}");
+					content.Headers.Add("X-Custom", "expected-value");
+					HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+						content,
+						CancellationToken.None);
+
+					await That(result.StatusCode)
+						.IsEqualTo(expectSuccess ? HttpStatusCode.OK : HttpStatusCode.NotImplemented);
+				}
+
+				[Fact]
+				public async Task Do_ShouldForwardToInnerParameter()
+				{
+					int invocationCount = 0;
+					HttpClient httpClient = HttpClient.CreateMock();
+					httpClient.Mock.Setup
+						.PostAsync(It.IsAny<Uri>(),
+							It.IsHttpContent().WithJsonMatching(new
+							{
+								foo = 1,
+							}).Do(_ => invocationCount++))
+						.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+					HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+						new StringContent("{\"foo\": 1}"),
+						CancellationToken.None);
+
+					await That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
+					await That(invocationCount).IsEqualTo(1);
+				}
+			}
+
+			public sealed class ExactMatchWithoutIgnoringAdditionalPropertiesTests
+			{
+				[Fact]
+				public async Task WhenSubjectMatchesExpectedExactly_ShouldSucceed()
+				{
+					HttpClient httpClient = HttpClient.CreateMock();
+					httpClient.Mock.Setup
+						.PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithJsonMatching(new
+						{
+							foo = 1,
+							bar = 2,
+						}).IgnoringAdditionalProperties(false))
+						.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+					HttpResponseMessage result = await httpClient.PostAsync("https://www.aweXpect.com",
+						new StringContent("""
+						                  {
+						                    "foo": 1,
+						                    "bar": 2
+						                  }
+						                  """),
+						CancellationToken.None);
+
+					await That(result.StatusCode)
+						.IsEqualTo(HttpStatusCode.OK);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Adds additional unit test coverage for aweXpect.Mockolate around chained `It.IsHttpContent().WithJsonMatching(...)` matchers and negated verification (`DoesNotComplyWith(...)`) scenarios.

**Changes:**
- Add chained matcher tests for `WithMediaType`, `WithString`, `WithBytes`, `WithHeaders`, and `Do` on JSON HttpContent matchers.
- Add negated verification tests for `Times(...)`, `Then(...)`, and `Never()`.