### PR TITLE
coverage: add missing `Then` tests

### DIFF
--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
@@ -32,13 +32,13 @@ public static partial class ThatVerificationResult
 		: ConstraintResult.WithValue<VerificationResult<T>>(grammars),
 			IValueConstraint<VerificationResult<T>>
 	{
-		private readonly List<string> _expectations = [];
+		private List<string> _expectations = null!;
 		private string? _error;
 
 		public ConstraintResult IsMetBy(VerificationResult<T> actual)
 		{
 			Actual = actual;
-			_expectations.Clear();
+			_expectations = new List<string>();
 			bool result = true;
 			T verify = ((IVerificationResult<T>)actual).Object;
 			IVerificationResult verificationResult = actual;
@@ -73,10 +73,11 @@ public static partial class ThatVerificationResult
 			bool VerifyInteractions(IInteraction[] filteredInteractions, IVerificationResult currentVerificationResult)
 			{
 				bool hasInteractionAfter = filteredInteractions.Any(x => x.Index > after);
-				after = hasInteractionAfter
-					? filteredInteractions.Where(x => x.Index > after).Min(x => x.Index)
-					: int.MaxValue;
-				if (!hasInteractionAfter && _error is null)
+				if (hasInteractionAfter)
+				{
+					after = filteredInteractions.Where(x => x.Index > after).Min(x => x.Index);
+				}
+				else if (_error is null)
 				{
 					_error = filteredInteractions.Length > 0
 						? $"{currentVerificationResult.Expectation} too early"

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.Then.cs
@@ -32,7 +32,7 @@ public static partial class ThatVerificationResult
 		: ConstraintResult.WithValue<VerificationResult<T>>(grammars),
 			IValueConstraint<VerificationResult<T>>
 	{
-		private List<string> _expectations = null!;
+		private List<string>? _expectations;
 		private string? _error;
 
 		public ConstraintResult IsMetBy(VerificationResult<T> actual)
@@ -91,7 +91,7 @@ public static partial class ThatVerificationResult
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
 			string separator = $", then{Environment.NewLine}{indentation}";
-			stringBuilder.Append(string.Join(separator, _expectations)).Append(" in order");
+			stringBuilder.Append(string.Join(separator, _expectations!)).Append(" in order");
 		}
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
@@ -100,7 +100,7 @@ public static partial class ThatVerificationResult
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
 			string separator = $", then{Environment.NewLine}{indentation}";
-			stringBuilder.Append(string.Join(separator, _expectations)).Append(" not in order");
+			stringBuilder.Append(string.Join(separator, _expectations!)).Append(" not in order");
 		}
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)

--- a/Source/aweXpect.Mockolate/ThatVerificationResult.cs
+++ b/Source/aweXpect.Mockolate/ThatVerificationResult.cs
@@ -50,8 +50,8 @@ public static partial class ThatVerificationResult
 		: ConstraintResult.WithValue<VerificationResult<TVerify>>(grammars),
 			IAsyncConstraint<VerificationResult<TVerify>>
 	{
-		private int _count = -1;
-		private string _expectation = "";
+		private int _count;
+		private string? _expectation;
 
 		public async Task<ConstraintResult> IsMetBy(VerificationResult<TVerify> actual,
 			CancellationToken cancellationToken)
@@ -149,6 +149,7 @@ public static partial class ThatVerificationResult
 			}
 			else
 			{
+				// Stryker disable once Equality : unreachable boundary — AppendNormalResult only runs when _count != expected
 				stringBuilder.Append("found ").Append(it).Append(_count < expected ? " only " : " ")
 					.Append(_count.ToAmountString());
 			}
@@ -191,8 +192,8 @@ public static partial class ThatVerificationResult
 		: ConstraintResult.WithValue<VerificationResult<TVerify>>(grammars),
 			IValueConstraint<VerificationResult<TVerify>>
 	{
-		private int _count = -1;
-		private string _expectation = "";
+		private int _count;
+		private string? _expectation;
 
 		public ConstraintResult IsMetBy(VerificationResult<TVerify> actual)
 		{
@@ -261,8 +262,8 @@ public static partial class ThatVerificationResult
 		: ConstraintResult.WithValue<VerificationResult<TVerify>>(grammars),
 			IAsyncConstraint<VerificationResult<TVerify>>
 	{
-		private int _count = -1;
-		private string _expectation = "";
+		private int _count;
+		private string? _expectation;
 
 		public async Task<ConstraintResult> IsMetBy(VerificationResult<TVerify> actual,
 			CancellationToken cancellationToken)

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
@@ -48,18 +48,6 @@ public sealed partial class ThatVerificationResultIs
 		}
 
 		[Fact]
-		public async Task Then_WhenBothFiltersMatchSameSingleInteraction_ShouldFail()
-		{
-			IMyService sut = IMyService.CreateMock();
-
-			sut.MyMethod(1);
-
-			await That(async Task () => await That(sut.Mock.Verify.MyMethod(It.Is(1)))
-					.Then(m => m.MyMethod(It.Is(1))))
-				.Throws<XunitException>();
-		}
-
-		[Fact]
 		public async Task Then_WhenFirstFilterMatchesMultipleInteractions_ShouldUseEarliestIndex()
 		{
 			IMyService sut = IMyService.CreateMock();
@@ -69,6 +57,18 @@ public sealed partial class ThatVerificationResultIs
 			sut.MyMethod(1);
 
 			await That(sut.Mock.Verify.MyMethod(It.Is(1))).Then(m => m.MyMethod(It.Is(2)));
+		}
+
+		[Fact]
+		public async Task Then_WhenInitialAndThenFiltersMatchSameSingleInteraction_ShouldFail()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			sut.MyMethod(1);
+
+			await That(async Task () => await That(sut.Mock.Verify.MyMethod(It.Is(1)))
+					.Then(m => m.MyMethod(It.Is(1))))
+				.Throws<XunitException>();
 		}
 
 		[Fact]

--- a/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
+++ b/Tests/aweXpect.Mockolate.Tests/ThatVerificationResultIs.ThenTests.cs
@@ -48,6 +48,30 @@ public sealed partial class ThatVerificationResultIs
 		}
 
 		[Fact]
+		public async Task Then_WhenBothFiltersMatchSameSingleInteraction_ShouldFail()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			sut.MyMethod(1);
+
+			await That(async Task () => await That(sut.Mock.Verify.MyMethod(It.Is(1)))
+					.Then(m => m.MyMethod(It.Is(1))))
+				.Throws<XunitException>();
+		}
+
+		[Fact]
+		public async Task Then_WhenFirstFilterMatchesMultipleInteractions_ShouldUseEarliestIndex()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			sut.MyMethod(1);
+			sut.MyMethod(2);
+			sut.MyMethod(1);
+
+			await That(sut.Mock.Verify.MyMethod(It.Is(1))).Then(m => m.MyMethod(It.Is(2)));
+		}
+
+		[Fact]
 		public async Task Then_WhenNoMatch_ShouldReturnFalse()
 		{
 			IMyService sut = IMyService.CreateMock();
@@ -136,6 +160,20 @@ public sealed partial class ThatVerificationResultIs
 				               [3] invoke method MyMethod(4)
 				             ]
 				             """);
+		}
+
+		[Fact]
+		public async Task Then_WhenSecondFilterMatchesAtAndAfterEarliest_ShouldAdvanceStrictly()
+		{
+			IMyService sut = IMyService.CreateMock();
+
+			sut.MyMethod(1);
+			sut.MyMethod(3);
+			sut.MyMethod(2);
+
+			await That(async Task () => await That(sut.Mock.Verify.MyMethod(It.Is(1)))
+					.Then(m => m.MyMethod(It.IsAny<int>()), m => m.MyMethod(It.Is(3))))
+				.Throws<XunitException>();
 		}
 
 		public sealed class NegatedTests


### PR DESCRIPTION
This PR increases coverage around `That(...).Then(...)` ordering verification for Mockolate interaction assertions, and adjusts implementation details in the `Then` constraint and some verification-count constraints.

**Changes:**
- Add new unit tests covering edge cases for `Then` ordering (single-interaction overlap, earliest-match selection, strict advancement).
- Update `ThenConstraint`’s internal expectations tracking and interaction index advancement logic.
- Adjust internal fields in count-based constraints (`HasExactly`, `HasAtMost`, `HasAtLeast`) to use default initialization / nullable expectation strings.