### PR TITLE
refactor: re-enable mutation tests

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -22,7 +22,7 @@ namespace Build;
 
 partial class Build
 {
-	private static readonly bool DisableMutationTests = true;
+	private static readonly bool DisableMutationTests = false;
 	static string MutationCommentBody = "";
 
 	Target MutationTests => _ => _


### PR DESCRIPTION
Re-enables mutation testing in the Nuke build pipeline so CI workflows that invoke the `MutationTests` target will execute Stryker again.

**Changes:**
- Flip the build-time flag to stop skipping mutation test targets by default.