### PR TITLE
chore: bump Mockolate to v3.0.0-pre.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 		<PackageVersion Include="aweXpect" Version="2.31.0"/>
 		<PackageVersion Include="aweXpect.Core" Version="2.28.0"/>
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0"/>
-		<PackageVersion Include="Mockolate" Version="3.0.0-pre.2"/>
+		<PackageVersion Include="Mockolate" Version="3.0.0-pre.3"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -22,7 +22,7 @@
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<NoWarn>$(NoWarn);1701;1702</NoWarn>
-		<WarningsNotAsErrors>CS1591;CS1711;NU5104</WarningsNotAsErrors>
+		<WarningsNotAsErrors>CS1591;NU5104</WarningsNotAsErrors>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 


### PR DESCRIPTION
Updates the repository’s centrally-managed NuGet dependency on Mockolate to the next pre-release version, with an additional build configuration tweak in the Source props.

**Changes:**
- Bump `Mockolate` from `3.0.0-pre.2` to `3.0.0-pre.3` via central package management.
- Tighten compiler warning policy by removing `CS1711` from `WarningsNotAsErrors` for Source builds.