### PR TITLE
chore: bump Mockolate to v3.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 		<PackageVersion Include="aweXpect" Version="2.31.0"/>
 		<PackageVersion Include="aweXpect.Core" Version="2.28.0"/>
 		<PackageVersion Include="aweXpect.Chronology" Version="1.0.0"/>
-		<PackageVersion Include="Mockolate" Version="3.0.0-pre.3"/>
+		<PackageVersion Include="Mockolate" Version="3.0.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>


### PR DESCRIPTION
This pull request updates the `Mockolate` package dependency to a stable release version. No other changes are included.

* Updated the `Mockolate` package version from `3.0.0-pre.3` (pre-release) to `3.0.0` (stable) in `Directory.Packages.props`.