### PR TITLE
docs: document missing features

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,26 @@ Verify that a method was called a specific number of times:
 var sut = IMyService.CreateMock();
 sut.MyMethod();
 
-await That(sut.Mock.Verify.MyMethod()).Once();             // Exactly once
-await That(sut.Mock.Verify.MyMethod()).Twice();            // Exactly twice
-await That(sut.Mock.Verify.MyMethod()).Never();            // Never called
-await That(sut.Mock.Verify.MyMethod()).AtLeastOnce();      // At least once
-await That(sut.Mock.Verify.MyMethod()).AtLeastTwice();     // At least twice
-await That(sut.Mock.Verify.MyMethod()).AtLeast(3.Times()); // At least 3 times
-await That(sut.Mock.Verify.MyMethod()).AtMostOnce();       // At most once
-await That(sut.Mock.Verify.MyMethod()).AtMostTwice();      // At most twice
-await That(sut.Mock.Verify.MyMethod()).AtMost(4.Times());  // At most 4 times
-await That(sut.Mock.Verify.MyMethod()).Exactly(2.Times()); // Exactly 2 times
+await That(sut.Mock.Verify.MyMethod()).Once();                    // Exactly once
+await That(sut.Mock.Verify.MyMethod()).Twice();                   // Exactly twice
+await That(sut.Mock.Verify.MyMethod()).Never();                   // Never called
+await That(sut.Mock.Verify.MyMethod()).AtLeastOnce();             // At least once
+await That(sut.Mock.Verify.MyMethod()).AtLeastTwice();            // At least twice
+await That(sut.Mock.Verify.MyMethod()).AtLeast(3.Times());        // At least 3 times
+await That(sut.Mock.Verify.MyMethod()).AtMostOnce();              // At most once
+await That(sut.Mock.Verify.MyMethod()).AtMostTwice();             // At most twice
+await That(sut.Mock.Verify.MyMethod()).AtMost(4.Times());         // At most 4 times
+await That(sut.Mock.Verify.MyMethod()).Exactly(2.Times());        // Exactly 2 times
+await That(sut.Mock.Verify.MyMethod()).Between(2).And(5.Times()); // Between 2 and 5 times
 ```
 
 #### Asynchronous verification
 
 With `Within(TimeSpan timeout)`, you can check whether the expected number of calls occurred within a given time
 interval. This is useful for asynchronous or delayed invocations in the background.
+
+`Within` and `WithCancellation` are available on `AtLeast*`, `Once`, `Twice`, `Exactly`, and `Between`. They are not
+available on `Never` or `AtMost*`, since an upper bound cannot be confirmed by waiting longer.
 
 ```csharp
 var sut = IMyService.CreateMock();
@@ -116,6 +120,8 @@ await That(sut.Mock.Verify).AllSetupsAreUsed();
 
 ### Web Extensions
 
+> Web extensions require .NET 8.0 or later.
+
 #### JSON Content
 
 You can precisely verify JSON content in HTTP requests during your tests. This feature is
@@ -130,5 +136,17 @@ httpClient.Mock.Setup
 // You can also provide a string representation of the JSON, and it ignores formatting differences or property order
 httpClient.Mock.Setup
     .PostAsync(It.IsAny<Uri>(), It.IsHttpContent().WithJson("{\"bar\": \"baz\", \"foo\": 1}"))
+    .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+```
+
+By default, additional properties in the actual JSON are ignored. Use `IgnoringAdditionalProperties(false)` to require
+an exact match:
+
+```csharp
+// Fails if the request body contains any property other than `foo` and `bar`
+httpClient.Mock.Setup
+    .PostAsync(It.IsAny<Uri>(), It.IsHttpContent()
+        .WithJsonMatching(new { foo = 1, bar = "baz" })
+        .IgnoringAdditionalProperties(false))
     .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
 ```


### PR DESCRIPTION
This pull request updates the `README.md` to document new verification features and clarify usage details for web extensions and JSON content matching. The most important changes are grouped below:

### Verification API Documentation Improvements

* Added documentation for the new `Between(...).And(...Times())` verification method, allowing users to assert that a method was called between a minimum and maximum number of times.
* Clarified that `Within` and `WithCancellation` are available on `AtLeast*`, `Once`, `Twice`, `Exactly`, and `Between`, but not on `Never` or `AtMost*` verifications.

### Web Extensions Requirements

* Noted that web extensions require .NET 8.0 or later.

### JSON Content Matching Enhancements

* Documented that, by default, additional properties in actual JSON are ignored during HTTP request verification, and introduced the `IgnoringAdditionalProperties(false)` option for requiring an exact match. Provided a code example demonstrating this stricter matching.