### PR TITLE
chore: move SonarCloud project to Testably organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ All code should be covered by unit tests and comply with the coding guideline in
 
 As a framework for supporting unit testing, this project has a high standard for testing itself.  
 In order to support this, static code analysis is performed
-using [SonarCloud](https://sonarcloud.io/project/overview?id=Testably_aweXpect.Mockolate) with quality gate requiring to
+using [SonarCloud](https://sonarcloud.io/project/overview?id=Testably_aweXpect.Mockolate) with a quality gate that requires:
 
-- solve all issues reported by SonarCloud
-- have a code coverage of > 90%
+- all issues reported by SonarCloud to be resolved
+- code coverage to be > 90%

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ All code should be covered by unit tests and comply with the coding guideline in
 
 As a framework for supporting unit testing, this project has a high standard for testing itself.  
 In order to support this, static code analysis is performed
-using [SonarCloud](https://sonarcloud.io/project/overview?id=aweXpect_aweXpect.Mockolate) with quality gate requiring to
+using [SonarCloud](https://sonarcloud.io/project/overview?id=Testably_aweXpect.Mockolate) with quality gate requiring to
 
 - solve all issues reported by SonarCloud
 - have a code coverage of > 90%

--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -16,8 +16,8 @@ partial class Build
 		.Executes(() =>
 		{
 			SonarScannerTasks.SonarScannerBegin(s => s
-				.SetOrganization("awexpect")
-				.SetProjectKey("aweXpect_aweXpect.Mockolate")
+				.SetOrganization("testably")
+				.SetProjectKey("Testably_aweXpect.Mockolate")
 				.AddVSTestReports(TestResultsDirectory / "*.trx")
 				.AddOpenCoverPaths(TestResultsDirectory / "reports" / "OpenCover.xml")
 				.SetPullRequestOrBranchName(GitHubActions, GitVersion)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Mockolate)](https://www.nuget.org/packages/aweXpect.Mockolate)
 [![Build](https://github.com/aweXpect/aweXpect.Mockolate/actions/workflows/build.yml/badge.svg)](https://github.com/aweXpect/aweXpect.Mockolate/actions/workflows/build.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Mockolate&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aweXpect_aweXpect.Mockolate)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Mockolate&metric=coverage)](https://sonarcloud.io/summary/overall?id=aweXpect_aweXpect.Mockolate)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Mockolate&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_aweXpect.Mockolate)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Mockolate&metric=coverage)](https://sonarcloud.io/summary/overall?id=Testably_aweXpect.Mockolate)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FaweXpect.Mockolate%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/aweXpect.Mockolate/main)
 
 Expectations to verify interactions with mocks from [Mockolate](https://github.com/aweXpect/Mockolate).


### PR DESCRIPTION
Updates the sonar organization to testably and renames the project key to Testably_aweXpect.Mockolate to match the new SonarCloud organization. README badges and CONTRIBUTING link are updated accordingly.