### PR TITLE
docs: remove UTF-8 BOM from Docs/pages/00-index.md

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,4 +1,4 @@
-﻿# aweXpect.Mockolate
+# aweXpect.Mockolate
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Mockolate)](https://www.nuget.org/packages/aweXpect.Mockolate)
 


### PR DESCRIPTION
The BOM preceded the page H1 (`# aweXpect.Mockolate`), so the docs site rendered it as a literal paragraph instead of a heading. Stripping the BOM lets markdown parse the heading correctly.